### PR TITLE
import ssh key pairs to aws via terraform

### DIFF
--- a/cloud/terraform/sample/resources.json
+++ b/cloud/terraform/sample/resources.json
@@ -7,6 +7,20 @@
             "instance_type": "",
             "username": "ec2-user",
             "name": "sample-name-RHEL-8.6"
+        },
+        {
+            "ami": "ami-09d21608cdeb79c49",
+            "region": "us-east-1",
+            "instance_type": "",
+            "username": "ec2-user",
+            "name": "sample-name-2-CentOS-stream-9"
+        },
+        {
+            "ami": "ami-02aaa61ea41b30dae",
+            "region": "us-west-2",
+            "instance_type": "",
+            "username": "ec2-user",
+            "name": "sample-name-3-RHEL-8.6"
         }
     ]
 }

--- a/cloud/terraform/terraform_configurator.py
+++ b/cloud/terraform/terraform_configurator.py
@@ -20,14 +20,15 @@ class TerraformConfigurator:
             }
 
     def configure_from_resources_json(self, resources_path):
+        self.resources_path = resources_path
         with open(resources_path) as f:
             resources_file = json.load(f)
 
         if resources_file['provider'] == 'aws':
             self.configure_aws_resources(resources_file)
 
-    def configure_aws_resources(self, resource_file):
-        for instance in resource_file['instances']:
+    def configure_aws_resources(self, resources_file):
+        for instance in resources_file['instances']:
             self.add_region_conf(instance['region'])
             self.add_instance_conf(instance)
             self.add_ssh_key_conf(instance['region'])
@@ -115,3 +116,15 @@ class TerraformConfigurator:
 
     def set_aws_profile(self, profile):
         self.aws_profile = profile
+
+    def get_username_by_instance_name(self, name):
+        with open(self.resources_path) as f:
+            resources_file = json.load(f)
+
+        for instance in resources_file['instances']:
+            if instance['name'].replace('.', '-') == name:
+                return instance['username']
+            
+        print(f'ERROR: No instance with name "{name}" was found')
+        exit(1)
+        

--- a/cloud/terraform/terraform_configurator.py
+++ b/cloud/terraform/terraform_configurator.py
@@ -4,9 +4,10 @@ from pprint import pprint
 
 
 class TerraformConfigurator:
-    def __init__(self, cloud, ssh_key_path):
+    def __init__(self, cloud, ssh_key_path, resources_path):
         self.cloud = cloud
         self.ssh_key_path = ssh_key_path
+        self.resources_path = resources_path
 
         self.main_tf = {'terraform': {'required_version': '>= 0.14.9'}}
         self.resources_tf = {'resource': {}}
@@ -19,9 +20,8 @@ class TerraformConfigurator:
                 'aws': {'source': 'hashicorp/aws', 'version': '~> 3.27'}
             }
 
-    def configure_from_resources_json(self, resources_path):
-        self.resources_path = resources_path
-        with open(resources_path) as f:
+    def configure_from_resources_json(self):
+        with open(self.resources_path) as f:
             resources_file = json.load(f)
 
         if resources_file['provider'] == 'aws':
@@ -91,7 +91,7 @@ class TerraformConfigurator:
         new_key_pair = {
             'provider': f'aws.{region}',
             'key_name': key_name,
-            'public_key': f'${{file(\"{self.ssh_key_path}.pub")}}',
+            'public_key': f'${{file("{self.ssh_key_path}.pub")}}',
         }
 
         self.resources_tf['resource']['aws_key_pair'][key_name] = new_key_pair
@@ -127,4 +127,3 @@ class TerraformConfigurator:
             
         print(f'ERROR: No instance with name "{name}" was found')
         exit(1)
-        

--- a/cloud/terraform/terraform_configurator.py
+++ b/cloud/terraform/terraform_configurator.py
@@ -4,16 +4,20 @@ from pprint import pprint
 
 
 class TerraformConfigurator:
-    def __init__(self, cloud):
+    def __init__(self, cloud, ssh_key_path):
         self.cloud = cloud
+        self.ssh_key_path = ssh_key_path
+
         self.main_tf = {'terraform': {'required_version': '>= 0.14.9'}}
+        self.resources_tf = {'resource': {}}
+        self.providers_tf = {'provider': {cloud: []}}
 
         if cloud == 'aws':
-            self.cloud_instance = 'aws_instance'
-            self.main_tf['terraform']['required_providers'] = {'aws': {'source': 'hashicorp/aws', 'version': '~> 3.27'}}
-
-        self.resources_tf = {'resource': {self.cloud_instance: {}}}
-        self.providers_tf = {'provider': {cloud: []}}
+            self.resources_tf['resource']['aws_instance'] = {}
+            self.resources_tf['resource']['aws_key_pair'] = {}
+            self.main_tf['terraform']['required_providers'] = {
+                'aws': {'source': 'hashicorp/aws', 'version': '~> 3.27'}
+            }
 
     def configure_from_resources_json(self, resources_path):
         with open(resources_path) as f:
@@ -26,6 +30,7 @@ class TerraformConfigurator:
         for instance in resource_file['instances']:
             self.add_region_conf(instance['region'])
             self.add_instance_conf(instance)
+            self.add_ssh_key_conf(instance['region'])
 
     def add_region_conf(self, region):
         # Do not create provider block if it already exists
@@ -70,9 +75,25 @@ class TerraformConfigurator:
             'instance_type': instance['instance_type'],
             'ami': instance['ami'],
             'provider': f'aws.{instance["region"]}',
+            'key_name': f'{instance["region"]}-key',
             'tags': {'name': name},
         }
         self.resources_tf['resource']['aws_instance'][name] = new_instance
+
+    def add_ssh_key_conf(self, region):
+        if self.cloud == 'aws':
+            self.__new_aws_key_pair(region)
+
+    def __new_aws_key_pair(self, region):
+        key_name = f'{region}-key'
+        
+        new_key_pair = {
+            'provider': f'aws.{region}',
+            'key_name': key_name,
+            'public_key': f'${{file(\"{self.ssh_key_path}.pub")}}',
+        }
+
+        self.resources_tf['resource']['aws_key_pair'][key_name] = new_key_pair
 
     def set_configuration(self):
         self.__dump_to_json(self.main_tf, 'main.tf.json')
@@ -88,7 +109,7 @@ class TerraformConfigurator:
         pprint(self.providers_tf)
 
     def remove_configuration(self):
-        for file in ['main.tf', 'resources.tf', 'providers.tf']:
+        for file in ['main.tf.json', 'resources.tf.json', 'providers.tf.json']:
             if os.path.exists(file):
                 os.remove(file)
 

--- a/cloud/terraform/terraform_controller.py
+++ b/cloud/terraform/terraform_controller.py
@@ -1,7 +1,5 @@
 import os
 import json
-from typing import final
-from wsgiref.simple_server import WSGIRequestHandler
 
 from terraform_configurator import TerraformConfigurator
 
@@ -36,7 +34,7 @@ class TerraformController:
                     continue
 
                 username = self.tf_configurator.get_username_by_instance_name(
-                    resource['address'].replace('aws_instance.', '')
+                    resource['address'].split('.')[1]
                 )
                 instances_info[resource['address']] = {
                     'instance_id': resource['values']['id'],
@@ -63,12 +61,13 @@ class TerraformController:
 
 
 if __name__ == '__main__':
-    tf_conf = TerraformConfigurator('aws', '/tmp/test-key')
+    resources_test_file = os.path.join(os.path.dirname(__file__), 'sample/resources.json')
+
+    tf_conf = TerraformConfigurator('aws', '/tmp/test-key', resources_test_file)
     tf_controller = TerraformController('aws', tf_conf)
 
     try:
-        resources_test_file = os.path.join(os.path.dirname(__file__), 'sample/resources.json')
-        tf_conf.configure_from_resources_json(resources_test_file)
+        tf_conf.configure_from_resources_json()
         tf_conf.print_configuration()
         tf_conf.set_configuration()
 


### PR DESCRIPTION
to execute tests we need access to the generated instances via ssh.
Added functionality so new resources of type `aws_key_pair` are created,
one per region. Then, each instance get's this key added.