### PR TITLE
Optimize cli output

### DIFF
--- a/cloud/terraform/terraform_controller.py
+++ b/cloud/terraform/terraform_controller.py
@@ -3,17 +3,22 @@ import json
 
 
 class TerraformController:
-    def __init__(self, tf_configurator):
+    def __init__(self, tf_configurator, debug=False):
         self.cloud_name = tf_configurator.cloud_name
         self.tf_configurator = tf_configurator
+        self.debug = debug
+
+        self.debug_sufix = ''
+        if not debug:
+            self.debug_sufix = '1> /dev/null'
 
     def create_infra(self):
-        cmd_output = os.system('terraform init')
+        cmd_output = os.system(f'terraform init {self.debug_sufix}')
         if cmd_output:
             print('terraform init command failed, check configuration')
             exit(1)
 
-        cmd_output = os.system('terraform apply -auto-approve')
+        cmd_output = os.system(f'terraform apply -auto-approve {self.debug_sufix}')
         if cmd_output:
             print('terraform apply command failed, check configuration')
             exit(1)
@@ -91,6 +96,6 @@ class TerraformController:
             raise Exception('terraform destroy specific resource command failed')
 
     def destroy_infra(self):
-        cmd_output = os.system('terraform destroy -auto-approve')
+        cmd_output = os.system(f'terraform destroy -auto-approve {self.debug_sufix}')
         if cmd_output:
             raise Exception('terraform destroy command failed')

--- a/lib/console_lib.py
+++ b/lib/console_lib.py
@@ -1,0 +1,11 @@
+def color_print(text):
+    print('\033[95m' + text + '\033[0m')
+
+
+def print_divider(text):
+    divider_length = 75
+    free_spaces = int((divider_length / 2) - (len(text) / 2))
+
+    color_print('-' * divider_length)
+    color_print(' ' * free_spaces + text)
+    color_print('-' * divider_length)

--- a/main/cloud_image_validator.py
+++ b/main/cloud_image_validator.py
@@ -5,6 +5,7 @@ from pprint import pprint
 from cloud.terraform.terraform_controller import TerraformController
 from cloud.terraform.terraform_configurator import TerraformConfigurator
 from lib import ssh_lib
+from lib import console_lib
 from test_suite.suite_runner import SuiteRunner
 
 
@@ -32,10 +33,13 @@ class CloudImageValidator:
         self.infra_controller = self.initialize_infrastructure()
 
         try:
+            console_lib.print_divider('Deploying infrastructure')
             instances = self.deploy_infrastructure()
 
+            console_lib.print_divider('Running tests')
             self.run_tests_in_all_instances(instances)
         finally:
+            console_lib.print_divider('Cleanup')
             self.cleanup()
 
     def initialize_infrastructure(self):

--- a/main/cloud_image_validator.py
+++ b/main/cloud_image_validator.py
@@ -48,7 +48,7 @@ class CloudImageValidator:
         if self.debug:
             self.infra_configurator.print_configuration()
 
-        return TerraformController(self.infra_configurator)
+        return TerraformController(self.infra_configurator, self.debug)
 
     def deploy_infrastructure(self):
         self.infra_controller.create_infra()

--- a/test/test_cloud_image_validator.py
+++ b/test/test_cloud_image_validator.py
@@ -29,6 +29,8 @@ class TestCloudImageValidator:
         mock_initialize_infrastructure = mocker.MagicMock(return_value=test_controller)
         validator.initialize_infrastructure = mock_initialize_infrastructure
 
+        mock_print_divider = mocker.patch('lib.console_lib.print_divider')
+
         mock_deploy_infrastructure = mocker.MagicMock(return_value=self.test_instances)
         validator.deploy_infrastructure = mock_deploy_infrastructure
 
@@ -43,6 +45,11 @@ class TestCloudImageValidator:
 
         # Assert
         assert result is None
+        assert mock_print_divider.call_args_list == [
+            mocker.call('Deploying infrastructure'),
+            mocker.call('Running tests'),
+            mocker.call('Cleanup')
+        ]
 
         mock_initialize_infrastructure.assert_called_once()
         mock_deploy_infrastructure.assert_called_once()

--- a/test/test_terraform_controller.py
+++ b/test/test_terraform_controller.py
@@ -20,8 +20,8 @@ class TestTerraformController:
     def test_create_infra(self, mocker, tf_controller):
         # Arrange
         mock_os_system = mocker.patch('os.system', return_value='')
-        tf_init = 'terraform init'
-        tf_apply = 'terraform apply -auto-approve'
+        tf_init = f'terraform init {tf_controller.debug_sufix}'
+        tf_apply = f'terraform apply -auto-approve {tf_controller.debug_sufix}'
 
         # Acts
         result = tf_controller.create_infra()
@@ -181,7 +181,7 @@ class TestTerraformController:
     def test_destroy_infra(self, mocker, tf_controller):
         # Arrange
         mock_os_system = mocker.patch('os.system', return_value='')
-        tf_destroy_infra = 'terraform destroy -auto-approve'
+        tf_destroy_infra = f'terraform destroy -auto-approve {tf_controller.debug_sufix}'
 
         # Act
         result = tf_controller.destroy_infra()


### PR DESCRIPTION
terraform commands output can be very big and hard to read. Add a debug
option so the full ouput can be skipped.

Also organize cloud-image-val output in different sections