### PR TITLE
add test_sshd

### DIFF
--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -1,6 +1,5 @@
 import pytest
 from lib import test_lib
-import re
 
 
 class TestsGeneric:
@@ -175,20 +174,14 @@ class TestsGeneric:
         assert product_version.replace('.', '-') in cloud_image_name, 'product version is not in image name'
 
     def test_sshd(self, host):
-        """
-        sshd service shoud be on, password authentication shoud be disabled
-        """
         with host.sudo():
             sshd = host.service('sshd')
             assert sshd.is_running, 'ssh.service is not active'
 
-            sshd_config_string = host.file('/etc/ssh/sshd_config').content_string
-            pwdAuthNo = 'PasswordAuthentication no'
-            pwdAuthYes = 'PasswordAuthentication yes'
+            pass_auth_config_name = 'PasswordAuthentication'
 
-            if not re.match(pwdAuthNo, sshd_config_string) and \
-               not re.match(f'#[ ]?{pwdAuthYes}|#[ ]+{pwdAuthYes}', sshd_config_string):
-                pytest.fail('password authentication should be disabled')
+            assert host.file('/etc/ssh/sshd_config').contains(f'^{pass_auth_config_name} no'), \
+                f'{pass_auth_config_name} should be disabled (set to "no")'
 
 
 class TestsCloudInit:

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -173,6 +173,18 @@ class TestsGeneric:
             f'product version ({product_version}) does not match package release version'
         assert product_version.replace('.', '-') in cloud_image_name, 'product version is not in image name'
 
+    def test_sshd(self, host):
+        """
+        sshd service shoud be on, password authentication shoud be disabled
+        """
+        with host.sudo():
+            sshd = host.service('sshd')
+            assert sshd.is_running, 'ssh.service is not active'
+
+            if not host.file('/etc/ssh/sshd_config').contains('PasswordAuthentication no') and \
+               not host.file('/etc/ssh/sshd_config').contains('#PasswordAuthentication yes'):
+                pytest.fail('password authentication should be disabled')
+
 
 class TestsCloudInit:
     def test_growpart_is_present_in_config(self, host):

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -1,5 +1,6 @@
 import pytest
 from lib import test_lib
+import re
 
 
 class TestsGeneric:
@@ -181,8 +182,12 @@ class TestsGeneric:
             sshd = host.service('sshd')
             assert sshd.is_running, 'ssh.service is not active'
 
-            if not host.file('/etc/ssh/sshd_config').contains('PasswordAuthentication no') and \
-               not host.file('/etc/ssh/sshd_config').contains('#PasswordAuthentication yes'):
+            sshd_config_string = host.file('/etc/ssh/sshd_config').content_string
+            pwdAuthNo = 'PasswordAuthentication no'
+            pwdAuthYes = 'PasswordAuthentication yes'
+
+            if not re.match(pwdAuthNo, sshd_config_string) and \
+               not re.match(f'#[ ]?{pwdAuthYes}|#[ ]+{pwdAuthYes}', sshd_config_string):
                 pytest.fail('password authentication should be disabled')
 
 


### PR DESCRIPTION
ami-val tests that the instance uses systemctl. As cloud-image-val does not support rhel-6 or lower, this is not necessary.