### PR TITLE
Added markers option to run tests matching pytest markers expression.

### DIFF
--- a/cloud-image-val.py
+++ b/cloud-image-val.py
@@ -3,18 +3,27 @@ import os
 from argparse import ArgumentParser, RawTextHelpFormatter
 from main.cloud_image_validator import CloudImageValidator
 
-
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 
 parser.add_argument('-r', '--resources-file',
-                    help='Path to the resources_aws.json file that contains the Cloud provider and the images to use.\n'
-                         'See cloud/terraform/sample/resources_<cloud>.json to know about the expected file structure.',
+                    help='Path to the resources JSON file that contains the Cloud provider and the images to use.\n'
+                         'See cloud/sample/resources_<cloud>.json to know about the expected file structure.',
                     required=True)
 parser.add_argument('-o', '--output-file',
                     help='Output file path of the resultant Junit XML test report and others',
                     required=True)
 parser.add_argument('-t', '--test-filter',
                     help='Use this option to filter tests execution by test name',
+                    default=None,
+                    required=False)
+parser.add_argument('-m', '--include-markers',
+                    help='Use this option to specify which tests to run that match a pytest markers expression.\n'
+                         'The only marker currently supported is "pub" (see pytest.ini for more details)\n'
+                         'Example:\n'
+                         '\t-m "pub" --> run tests marked as "pub", which is for images are already published\n'
+                         '\t-m "not pub" --> exclude "pub" tests\n'
+                         'More information about pytest markers:\n'
+                         '--> https://doc.pytest.org/en/latest/example/markers.html',
                     default=None,
                     required=False)
 parser.add_argument('-p', '--parallel',
@@ -39,6 +48,7 @@ if __name__ == '__main__':
     cloud_image_validator = CloudImageValidator(resources_file=args.resources_file,
                                                 output_file=args.output_file,
                                                 test_filter=args.test_filter,
+                                                include_markers=args.include_markers,
                                                 parallel=args.parallel,
                                                 debug=args.debug)
     cloud_image_validator.main()

--- a/main/cloud_image_validator.py
+++ b/main/cloud_image_validator.py
@@ -23,11 +23,15 @@ class CloudImageValidator:
                  resources_file,
                  output_file,
                  test_filter=None,
+                 include_markers=None,
                  parallel=False,
                  debug=False):
         self.resources_file = resources_file
         self.output_file = output_file
+
         self.test_filter = test_filter
+        self.include_markers = include_markers
+
         self.parallel = parallel
         self.debug = debug
 
@@ -82,7 +86,9 @@ class CloudImageValidator:
                              parallel=self.parallel,
                              debug=self.debug)
 
-        runner.run_tests(self.output_file, self.test_filter)
+        runner.run_tests(self.output_file,
+                         self.test_filter,
+                         self.include_markers)
 
     def cleanup(self):
         self.infra_controller.destroy_infra()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    pub: Tests that have to be run on images that are already published into cloud providers' marketplaces.

--- a/test/test_cloud_image_validator.py
+++ b/test/test_cloud_image_validator.py
@@ -10,6 +10,7 @@ class TestCloudImageValidator:
     test_resources_file = '/fake/test/resources_file.json'
     test_output_file = '/fake/test/output_file.xml'
     test_filter = 'test_test_name'
+    test_markers = 'pub'
     test_parallel = True
     test_debug = True
     test_instances = ['test-instance-1', 'test-instance-2']
@@ -19,6 +20,7 @@ class TestCloudImageValidator:
         return CloudImageValidator(resources_file=self.test_resources_file,
                                    output_file=self.test_output_file,
                                    test_filter=self.test_filter,
+                                   include_markers=self.test_markers,
                                    parallel=self.test_parallel,
                                    debug=self.test_debug)
 
@@ -114,7 +116,7 @@ class TestCloudImageValidator:
 
         validator.run_tests_in_all_instances(self.test_instances)
 
-        mock_run_tests.assert_called_once_with(validator.output_file, self.test_filter)
+        mock_run_tests.assert_called_once_with(validator.output_file, self.test_filter, self.test_markers)
 
     def test_destroy_infrastructure(self, mocker, validator):
         mock_destroy_infra = mocker.patch.object(TerraformController, 'destroy_infra')

--- a/test/test_suite_runner.py
+++ b/test/test_suite_runner.py
@@ -9,6 +9,7 @@ class TestSuiteRunner:
     test_ssh_config = '/path/to/ssh_config'
     test_output_filepath = 'test/output/filepath.xml'
     test_filter = 'test_test_name'
+    test_marker = 'pub'
 
     @pytest.fixture
     def suite_runner(self):
@@ -29,34 +30,37 @@ class TestSuiteRunner:
         mock_os_system = mocker.patch('os.system')
 
         # Act
-        suite_runner.run_tests(test_output_filepath, self.test_filter)
+        suite_runner.run_tests(test_output_filepath, self.test_filter, self.test_marker)
 
         # Assert
         mock_os_path_exists.assert_called_once_with(test_output_filepath)
         mock_os_remove.assert_called_once_with(test_output_filepath)
 
         mock_os_system.assert_called_once_with(test_composed_command)
-        mock_compose_testinfra_command.assert_called_once_with(test_output_filepath, self.test_filter)
+        mock_compose_testinfra_command.assert_called_once_with(test_output_filepath,
+                                                               self.test_filter,
+                                                               self.test_marker)
 
     @pytest.mark.parametrize(
-        'test_filter, test_debug, test_parallel, expected_command_string',
-        [(None, False, False,
+        'test_filter, test_marker, test_debug, test_parallel, expected_command_string',
+        [(None, None, False, False,
           'py.test path1 path2 --hosts=user1@host1,user2@host2 '
           f'--ssh-config {test_ssh_config} --junit-xml {test_output_filepath} '
           f'--html {test_output_filepath.replace("xml", "html")}'),
-         (test_filter, False, False,
+         (test_filter, test_marker, False, False,
           'py.test path1 path2 --hosts=user1@host1,user2@host2 '
           f'--ssh-config {test_ssh_config} --junit-xml {test_output_filepath} '
           f'--html {test_output_filepath.replace("xml", "html")} '
-          f'-k "{test_filter}"'),
-         (None, False, True,
+          f'-k "{test_filter}" '
+          f'-m "{test_marker}"'),
+         (None, None, False, True,
           'py.test path1 path2 --hosts=user1@host1,user2@host2 '
           f'--ssh-config {test_ssh_config} --junit-xml {test_output_filepath} '
           f'--html {test_output_filepath.replace("xml", "html")} '
           f'--numprocesses={len(test_instances)} --maxprocesses=40 '
           '--only-rerun="refused|timeout|NoValidConnectionsError" '
           '--reruns 3 --reruns-delay 5'),
-         (None, True, True,
+         (None, None, True, True,
           'py.test path1 path2 --hosts=user1@host1,user2@host2 '
           f'--ssh-config {test_ssh_config} --junit-xml {test_output_filepath} '
           f'--html {test_output_filepath.replace("xml", "html")} '
@@ -69,6 +73,7 @@ class TestSuiteRunner:
                                        mocker,
                                        suite_runner,
                                        test_filter,
+                                       test_marker,
                                        test_debug,
                                        test_parallel,
                                        expected_command_string):
@@ -87,7 +92,8 @@ class TestSuiteRunner:
 
         # Act, Assert
         assert suite_runner.compose_testinfra_command(self.test_output_filepath,
-                                                      test_filter) == expected_command_string
+                                                      test_filter,
+                                                      test_marker) == expected_command_string
 
         mock_get_all_instances_hosts_with_users.assert_called_once()
 

--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -12,6 +12,7 @@ def instance_data_aws(host):
 
 
 class TestsAWS:
+    @pytest.mark.pub
     def test_ami_name(self, host, instance_data):
         """
         Check there is 'RHEL' in RHEL AMIs.
@@ -40,7 +41,7 @@ class TestsAWS:
             assert re.match(fedora_ami_name_format, ami_name), \
                 'Unexpected AMI name for Fedora image'
 
-    def test_rh_cloud_firstboot_service_is_disabled(self, host):
+    def test_rh_cloud_firstboot_service_is_disabled(self, host, rhel_only):
         """
         Check that rh-cloud-firstboot is disabled.
         """
@@ -54,7 +55,7 @@ class TestsAWS:
                 assert cloud_firstboot_file.contains('RUN_FIRSTBOOT=NO'), \
                     'rh-cloud-firstboot must be configured with RUN_FIRSTBOOT=NO'
 
-    def test_iommu_strict_mode(self, host):
+    def test_iommu_strict_mode(self, host, rhel_only):
         """
         Use "iommu.strict=0" in ARM AMIs to get better performance.
         BugZilla 1836058
@@ -74,7 +75,7 @@ class TestsAWS:
                 else:
                     assert iommu_option_present, f'{option} must be present in ARM AMIs'
 
-    def test_nouveau_is_blacklisted(self, host):
+    def test_nouveau_is_blacklisted(self, host, rhel_only):
         """
         Check that nouveau is disabled.
         BugZilla 1645772
@@ -96,7 +97,7 @@ class TestsAWS:
         assert host.file(file_to_check).contains('blacklist nouveau'), \
             f'nouveau is not blacklisted in "{file_to_check}"'
 
-    def test_unwanted_packages_are_not_present(self, host):
+    def test_unwanted_packages_are_not_present(self, host, rhel_only):
         """
         Some pkgs are not required in EC2.
         """
@@ -123,7 +124,7 @@ class TestsAWS:
 
         assert len(found_pkgs) == 0, f'Found unexpected packages installed: {", ".join(found_pkgs)}'
 
-    def test_required_packages_are_installed(self, host):
+    def test_required_packages_are_installed(self, host, rhel_only):
         """
         Some pkgs are required in EC2.
         https://kernel.googlesource.com/pub/scm/boot/dracut/dracut/+/18e61d3d41c8287467e2bc7178f32d188affc920%5E!/
@@ -178,10 +179,8 @@ class TestsAWS:
 
         assert len(missing_pkgs) == 0, f'Missing packages: {", ".join(missing_pkgs)}'
 
-    def test_rhui_pkg_is_installed(self, host):
-        if host.system_info.distribution == 'fedora':
-            pytest.skip('Fedora AMIs do not require rhui pkg')
-
+    @pytest.mark.pub
+    def test_rhui_pkg_is_installed(self, host, rhel_only):
         unwanted_rhui_pkgs = None
 
         if test_lib.is_rhel_high_availability(host):
@@ -203,7 +202,7 @@ class TestsAWS:
         assert host.package(required_rhui_pkg).is_installed, \
             f'Package "{required_rhui_pkg}" should be present'
 
-    def test_amazon_timesync_service_is_used(self, host):
+    def test_amazon_timesync_service_is_used(self, host, rhel_only):
         """
         BugZilla 1679763
         """
@@ -234,7 +233,7 @@ class TestsAWS:
             assert f'Selected source {timesync_service_ipv4}' in host.check_output('journalctl -u chronyd'), \
                 'Amazon Time Sync service is not in use'
 
-    def test_max_cstate_is_configured_in_cmdline(self, host):
+    def test_max_cstate_is_configured_in_cmdline(self, host, rhel_only):
         """
         Check that intel_idle.max_cstate=1 processor.max_cstate=1 exists in SAP AMI's /proc/cmdline.
         BugZilla 1961225
@@ -264,7 +263,7 @@ class TestsAWS:
                 assert host.file(f'/etc/ssh/{file}').mode >= 0o640, \
                     'ssh files permissions are not set correctly'
 
-    def test_aws_instance_identity(self, host, instance_data, instance_data_aws):
+    def test_aws_instance_identity(self, host, instance_data, instance_data_aws, rhel_only):
         """
         Try to fetch instance identity from EC2 and compare with expectation
         """
@@ -280,9 +279,6 @@ class TestsAWS:
 
         assert arch == host.system_info.arch, \
             'Unexpected architecture for deployed instance'
-
-        if host.system_info.distribution == 'fedora':
-            pytest.skip('No need to check billing codes in Fedora AMIs')
 
         ami_name = instance_data['name']
 
@@ -302,7 +298,7 @@ class TestsAWS:
             assert code in instance_data_aws['billingProducts'], \
                 'Expected billing code not found in instance document data'
 
-    def test_cmdline_nvme_io_timeout(self, host):
+    def test_cmdline_nvme_io_timeout(self, host, rhel_only):
         """
         Check if default value of /sys/module/nvme_core/parameters/io_timeout is set to 4294967295.
         BugZilla 1732506
@@ -320,7 +316,7 @@ class TestsAWS:
             assert host.file('/sys/module/nvme_core/parameters/io_timeout').contains(expected_value), \
                 f'Actual value in io_timeout is not {expected_value}'
 
-    def test_udev_kernel(self, host):
+    def test_udev_kernel(self, host, rhel_only):
         """
         This is from ks file definition before migrating to ImageBuilder.
         There is "70-persistent-net.rules" in all AMis and "80-net-name-slot.rules" in AMIs earlier than RHEL-8.4.
@@ -338,7 +334,7 @@ class TestsAWS:
             assert host.file('/etc/udev/rules.d/70-persistent-net.rules').exists, \
                 '70-persistent-net rules are required'
 
-    def test_libc6_xen_conf_file_does_not_exist(self, host):
+    def test_libc6_xen_conf_file_does_not_exist(self, host, rhel_only):
         """
         Check for /etc/ld.so.conf.d/libc6-xen.conf absence on RHEL
         """
@@ -400,7 +396,7 @@ class TestsAWSNetworking:
         assert registered_ipv6 in host.interface('eth0', 'inet6').addresses(), \
             f'Expected IPv6 {registered_ipv6} is not being used by eth0 network adapter'
 
-    def test_redhat_cds_hostnames(self, host, instance_data_aws):
+    def test_redhat_cds_hostnames(self, host, instance_data_aws, rhel_only):
         """
         Check all Red Hat CDS for the AMI's instance region.
         """

--- a/test_suite/conftest.py
+++ b/test_suite/conftest.py
@@ -5,6 +5,12 @@ from py.xml import html
 from pytest_html import extras
 
 
+@pytest.fixture
+def rhel_only(host):
+    if host.system_info.distribution != 'rhel':
+        pytest.skip('Image is not RHEL')
+
+
 @pytest.fixture(autouse=True)
 def instance_data(host):
     return __get_instance_data_from_json(key_to_find='public_dns',
@@ -21,30 +27,44 @@ def __get_instance_data_from_json(key_to_find, value_to_find):
 
 
 @pytest.fixture(autouse=True)
-def html_report_links(extra, instance_data):
-    extra.append(extras.json(instance_data))
+def html_report_links(extra, host, instance_data):
+    extra.append(extras.json(instance_data, 'Instance JSON'))
+
+    link_name = f'{host.system_info.distribution}-{host.system_info.release}'
+    extra.append(extras.json(vars(host.system_info)['sysinfo'], name=link_name))
 
 
 def pytest_configure(config):
-    config._metadata['GitHub'] = 'https://github.com/osbuild/cloud-image-val'
+    pytest.markers_used = config.getoption('-m')
 
 
 def pytest_html_report_title(report):
     report.title = 'Cloud Image Validation Report'
 
 
+def pytest_html_results_summary(prefix, summary, postfix):
+    prefix.extend([html.a('GitHub: https://github.com/osbuild/cloud-image-val',
+                          href='https://github.com/osbuild/cloud-image-val')])
+
+    if pytest.markers_used:
+        postfix.extend([html.h4(f'Markers used: {pytest.markers_used}')])
+
+
 def pytest_html_results_table_header(cells):
-    cells.insert(2, html.th('Image Reference', class_='sortable'))
-    cells.insert(3, html.th('Description'))
-    cells.insert(4, html.th('Error Message'))
+    del cells[1]
+
+    cells.insert(1, html.th('Test Case', class_='sortable'))
+    cells.insert(2, html.th('Description'))
+    cells.insert(3, html.th('Image Reference', class_='sortable'))
 
 
 def pytest_html_results_table_row(report, cells):
-    cells.insert(2, html.td(getattr(report, 'image_reference', '')))
-    cells.insert(3, html.td(getattr(report, 'description', ''),
+    del cells[1]
+
+    cells.insert(1, html.td(getattr(report, 'test_case', '')))
+    cells.insert(2, html.td(getattr(report, 'description', ''),
                             style='white-space:pre-line; word-wrap:break-word'))
-    cells.insert(4, html.td(getattr(report, 'error_message', ''),
-                            style='white-space:pre-line; word-wrap:break-word'))
+    cells.insert(3, html.td(getattr(report, 'image_reference', '')))
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -55,24 +75,18 @@ def pytest_runtest_makereport(item, call):
     # Set the test cases "Duration" format
     setattr(report, 'duration_formatter', '%S.%f sec')
 
-    # Fill "Image Reference" column
-    instance = item.funcargs['instance_data']
-    if instance:
-        image_ref = instance['ami'] if 'ami' in instance else instance['image']
-        report.image_reference = str(image_ref)
+    # Fill "Test Case" column
+    report.test_case = f'{str(item.parent.name)}::{str(item.function.__name__)}'
 
     # Fill "Description" column
-    description_text = __truncate_text(str(item.function.__doc__), 200)
+    description_text = __truncate_text(str(item.function.__doc__), 120)
     report.description = description_text
 
-    # Fill "Error Message" column
-    setattr(item, 'rep_' + report.when, report)
-    report.error_message = str(call.excinfo.value) if call.excinfo else ''
-    if report.when == 'teardown':
-        message = item.rep_call.error_message.split(' assert ')[0]
-        message = __truncate_text(message, 120)
-
-        report.error_message = message
+    # Fill "Image Reference" column
+    if 'instance_data' in item.funcargs:
+        instance = item.funcargs['instance_data']
+        image_ref = instance['ami'] if 'ami' in instance else instance['image']
+        report.image_reference = str(image_ref)
 
 
 def __truncate_text(text, max_chars):

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -20,7 +20,7 @@ class TestsGeneric:
         assert host.file('/proc/cmdline').contains('console=ttyS0'), \
             'Serial console should be redirected to ttyS0'
 
-    def test_crashkernel_is_enabled_rhel_6(self, host):
+    def test_crashkernel_is_enabled_rhel_6(self, host, rhel_only):
         """
         (deprecated)
         Check that crashkernel is enabled in image (RHEL 6 and below).
@@ -33,7 +33,7 @@ class TestsGeneric:
         else:
             pytest.skip('RHEL is 7.x or later')
 
-    def test_crashkernel_is_enabled_rhel_7_and_above(self, host):
+    def test_crashkernel_is_enabled_rhel_7_and_above(self, host, rhel_only):
         """
         Check that crashkernel is enabled in image (RHEL 7 and above).
         """
@@ -113,7 +113,7 @@ class TestsGeneric:
             assert 'no matches' in host.check_output('x=$(ausearch -m avc 2>&1 &); echo $x'), \
                 'There should not be any avc denials (selinux)'
 
-    def test_cert_product_version_is_correct(self, host):
+    def test_cert_product_version_is_correct(self, host, rhel_only):
         """
         BugZilla 1938930
         Issue RHELPLAN-60817
@@ -152,7 +152,7 @@ class TestsGeneric:
                     assert 'si::sysinit:/etc/rc.d/rc.sysinit' in host.check_output("grep '^si:' /etc/inittab"), \
                         'Unexpected default inittab "id"'
 
-    def test_release_version(self, host, instance_data):
+    def test_release_version(self, host, instance_data, rhel_only):
         """
         Check if rhel provider matches /etc/redhat-release and ami name
         """
@@ -174,7 +174,7 @@ class TestsGeneric:
             f'product version ({product_version}) does not match package release version'
         assert str(product_version).replace('.', '-') in cloud_image_name, 'product version is not in image name'
 
-    def test_root_is_locked(self, host):
+    def test_root_is_locked(self, host, rhel_only):
         """
         Check if root account is locked
         """
@@ -211,7 +211,7 @@ class TestsServices:
             assert host.file('/etc/ssh/sshd_config').contains(f'^{pass_auth_config_name} no'), \
                 f'{pass_auth_config_name} should be disabled (set to "no")'
 
-    def test_auditd(self, host):
+    def test_auditd(self, host, rhel_only):
         """
         - Service should be running
         - Config files should have the correct MD5 checksums
@@ -306,7 +306,7 @@ class TestsNetworking:
 
 
 class TestsSecurity:
-    def test_firewalld_is_disabled(self, host):
+    def test_firewalld_is_disabled(self, host, rhel_only):
         """
         firewalld is not required in cloud because there are security groups or other security mechanisms.
         """


### PR DESCRIPTION
Added rhel_only fixture and updated tests cases that are only applicable to RHEL images.
Marked test cases as "pub", which are only applicable to published cloud images.
Improved HTML report with new summary element to know which markers have been used.
Improved HTML report column "Test Case" so that it displays a shorter name of the test executed.