### PR TITLE
test_rh_cloud_firstboot_service_is_disabled assertion error

### DIFF
--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -45,7 +45,7 @@ class TestsAWS:
         """
         Check that rh-cloud-firstboot is disabled.
         """
-        if host.service('rh-cloud-firstboot').is_valid:
+        if host.check_output('systemctl status rh-cloud-firstboot || echo false') != 'false':
             assert not host.service('rh-cloud-firstboot').is_enabled, \
                 'rh-cloud-firstboot service must be disabled'
 


### PR DESCRIPTION
test_rh_cloud_firstboot_service_is_disabled fails as `is_valid` creates an assertion error instead of returning 1 or 0.