### PR TITLE
Improved azure config builder

### DIFF
--- a/cloud/sample/resources_azure_vhd.json
+++ b/cloud/sample/resources_azure_vhd.json
@@ -1,0 +1,17 @@
+{
+  "subscription_id": "a5192c85-2bff-4433-ac37-69aad5fcc86a",
+  "resource_group": "cloud-experience",
+  "provider": "azure",
+  "instances": [
+    {
+      "vhd_uri": "https://rhimages.blob.core.windows.net/rhel/8.6/rhel-azure-8.6-20220531.sp.2.x86_64.vhd",
+      "location": "East US",
+      "name": "sample-rhel8.6-image-from-vhd"
+    },
+    {
+      "vhd_uri": "https://rhimages.blob.core.windows.net/rhel/9.0/rhel-azure-9.0-20220531.sp.2.x86_64.vhd",
+      "location": "East US",
+      "name": "sample-rhel9-image-from-vhd"
+    }
+  ]
+}


### PR DESCRIPTION
This update brings the possibility of deploying Azure VMs directly from a vhd blob URI.
The Terraform Controller will create an image based on a given vhd, and then create the VM based on that image.