### PR TITLE
add parallel gilab repository

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -4,7 +4,7 @@ name: Trigger GitLab CI
 
 on:
   workflow_run:
-    workflows: ["passing_workflow"]
+    workflows: ["Basic Tests"]
     types: [completed]
 
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,29 @@
+stages:
+  - init
+  - test
+
+.deps:
+  image: python:3.8
+  before_script:
+    - apt-get update && apt-get install -y gnupg software-properties-common
+    - curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
+    - apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+    - apt-get update && apt-get install terraform
+    - pip install -r requirements.txt
+
+init:
+  stage: init
+  script:
+    - schutzbot/update_github_status.sh start
+
+aws:
+  stage: test
+  extends: .deps
+  script:
+    - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} python3 cloud-image-val.py -r cloud/sample/resources_aws.json -d -p -m 'not pub' -o report.xml
+  after_script:
+    - schutzbot/update_github_status.sh update || true
+  artifacts:
+    paths:
+      - report.html
+    when: always

--- a/schutzbot/update_github_status.sh
+++ b/schutzbot/update_github_status.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+
+# Don't overwrite CI statuses on GitHub branches for nightly pipelines
+if [[ "$CI_PIPELINE_SOURCE" == "schedule" ]]; then
+    exit 0
+fi
+
+# if a user is logged in to the runner, wait until they're done
+while (( $(who -s | wc -l)  > 0 )); do
+    echo "Waiting for user(s) to log off"
+    sleep 30
+done
+
+if [[ $1 == "start" ]]; then
+  GITHUB_NEW_STATE="pending"
+  GITHUB_NEW_DESC="I'm currently testing this commit, be patient."
+elif [[ $1 == "finish" ]]; then
+  GITHUB_NEW_STATE="success"
+  GITHUB_NEW_DESC="I like this commit!"
+elif [[ $1 == "update" ]]; then
+  if [[ $CI_JOB_STATUS == "canceled" ]]; then
+    GITHUB_NEW_STATE="failure"
+    GITHUB_NEW_DESC="Someone told me to cancel this test run."
+  elif [[ $CI_JOB_STATUS == "failed" ]]; then
+    GITHUB_NEW_STATE="failure"
+    GITHUB_NEW_DESC="I'm sorry, something is odd about this commit."
+  else
+    exit 0
+  fi
+else
+  echo "unknown command"
+  exit 1
+fi
+
+echo "curl \
+    -u ${SCHUTZBOT_LOGIN} \
+    -X POST \
+    -H Accept: application/vnd.github.v3+json \
+    https://api.github.com/repos/osbuild/cloud-image-val/statuses/${CI_COMMIT_SHA} \
+    -d '{state:"'"${GITHUB_NEW_STATE}"'", description: "'"${GITHUB_NEW_DESC}"'", context: Schutzbot on GitLab, target_url: "'"${CI_PIPELINE_URL}"'"}'"
+
+curl \
+    -u "${SCHUTZBOT_LOGIN}" \
+    -X POST \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/repos/osbuild/cloud-image-val/statuses/${CI_COMMIT_SHA}" \
+    -d '{"state":"'"${GITHUB_NEW_STATE}"'", "description": "'"${GITHUB_NEW_DESC}"'", "context": "Schutzbot on GitLab", "target_url": "'"${CI_PIPELINE_URL}"'"}'


### PR DESCRIPTION
github actions has some limitations that can be solved by having a
parallel gitlab repo intended to run part of the CI.