### PR TITLE
add ci tag to every azure resource

### DIFF
--- a/cloud/terraform/aws_config_builder.py
+++ b/cloud/terraform/aws_config_builder.py
@@ -49,7 +49,7 @@ class AWSConfigBuilder(BaseConfigBuilder):
             'provider': f'aws.{region}',
             'key_name': key_name,
             'public_key': f'${{file("{self.ssh_key_path}")}}',
-            'tags': {self.ci_tag_key: 'true'},
+            'tags': {self.ci_tag_key: self.ci_test_value},
         }
 
         self.resources_tf['resource']['aws_key_pair'][key_name] = new_key_pair
@@ -70,7 +70,7 @@ class AWSConfigBuilder(BaseConfigBuilder):
             'ami': instance['ami'],
             'provider': f'aws.{instance["region"]}',
             'key_name': instance['aws_key_pair'],
-            'tags': {'name': name_tag, self.ci_tag_key: 'true'},
+            'tags': {'name': name_tag, self.ci_tag_key: self.ci_tag_key},
             'depends_on': [
                 'aws_key_pair.{}'.format(instance['aws_key_pair'])
             ]

--- a/cloud/terraform/azure_config_builder.py
+++ b/cloud/terraform/azure_config_builder.py
@@ -81,6 +81,7 @@ class AzureConfigBuilder(BaseConfigBuilder):
             'location': instance['location'],
             'resource_group_name': self.resource_group,
             'os_disk': os_disk,
+            'tags': {self.ci_tag_key: self.ci_test_value}
         }
 
         self.resources_tf['resource']['azurerm_image'][name] = new_image
@@ -94,6 +95,7 @@ class AzureConfigBuilder(BaseConfigBuilder):
             'address_space': ['10.0.0.0/16'],
             'location': instance['location'],
             'resource_group_name': self.resource_group,
+            'tags': {self.ci_tag_key: self.ci_test_value}
         }
 
         self.resources_tf['resource']['azurerm_virtual_network'][name] = new_virtual_network
@@ -124,6 +126,7 @@ class AzureConfigBuilder(BaseConfigBuilder):
             'location': instance['location'],
             'allocation_method': 'Static',
             'domain_name_label': instance['hostname'],
+            'tags': {self.ci_tag_key: self.ci_test_value}
         }
 
         self.resources_tf['resource']['azurerm_public_ip'][name] = new_public_ip
@@ -149,6 +152,7 @@ class AzureConfigBuilder(BaseConfigBuilder):
             'location': instance['location'],
             'resource_group_name': self.resource_group,
             'ip_configuration': ip_configuration,
+            'tags': {self.ci_tag_key: self.ci_test_value},
             'depends_on': [
                 'azurerm_virtual_network.{}'.format(instance['azurerm_virtual_network']),
                 'azurerm_subnet.{}'.format(instance['azurerm_subnet']),
@@ -190,6 +194,7 @@ class AzureConfigBuilder(BaseConfigBuilder):
                 azure_resource_name=instance['azurerm_network_interface'])],
             'os_disk': os_disk,
             'admin_ssh_key': admin_ssh_key,
+            'tags': {self.ci_tag_key: self.ci_test_value},
             'depends_on': [
                 'azurerm_virtual_network.{}'.format(instance['azurerm_virtual_network']),
                 'azurerm_subnet.{}'.format(instance['azurerm_subnet']),

--- a/cloud/terraform/base_config_builder.py
+++ b/cloud/terraform/base_config_builder.py
@@ -13,6 +13,7 @@ class BaseConfigBuilder:
 
     resource_name_prefix = 'civ'
     ci_tag_key = 'gitlab-ci-test'
+    ci_test_value = 'true'
 
     def __init__(self, resources_dict):
         self.resources_dict = resources_dict


### PR DESCRIPTION
this way, cloud cleaner can remove the leftover resources in case the is
any