### PR TITLE
remove profile from aws command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ Below you will find the specific requirements to make `cloud-image-val` tool wor
 The automation of some steps below will be automated in later versions of the tool (WIP).
 ### AWS
 - You must have a working AWS account.
-- The code is prepared to work with the **default profile** named `aws`.
-- The credentials must be stored in `~/.aws/credentials` for the `[aws]` profile.
-  - See https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_profiles.html for more details.
+- The code is prepared to work with authentication by environment variables:
+  - https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
 - **Inbound rules** must be set to **allow SSH** connection from (at least) your public IP address in the default Security Group or VPC.
 
 ### Azure

--- a/cloud/terraform/aws_config_builder.py
+++ b/cloud/terraform/aws_config_builder.py
@@ -23,11 +23,10 @@ class AWSConfigBuilder(BaseConfigBuilder):
 
         return list(dict.fromkeys(instances_regions))
 
-    def __new_aws_provider(self, region, aws_profile='aws'):
+    def __new_aws_provider(self, region):
         return {
             'region': region,
             'alias': region,
-            'profile': aws_profile,
         }
 
     def build_resources(self):

--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -15,13 +15,10 @@ def instance_data_aws_web(host):
 
 @pytest.fixture
 def instance_data_aws_cli(host, instance_data_aws_web):
-    # TODO: read AWS profile from somewhere, instead of being hardcoded
-    profile = 'aws'
     query_to_run = 'Reservations[].Instances[]'
 
     command_to_run = [
         'aws ec2 describe-instances',
-        f'--profile {profile}',
         '--instance-id {0}'.format(instance_data_aws_web['instanceId']),
         '--region {0}'.format(instance_data_aws_web['region']),
         f'--query "{query_to_run}"'


### PR DESCRIPTION
from now on CIV will use env varibles to authenticate into aws. Removing
the profile lets us use containers.