### PR TITLE
Suppressed output of dnf command when installing lshw utility.

### DIFF
--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -781,7 +781,7 @@ class TestsAWSNetworking:
         """
         with host.sudo():
             if host.system_info.distribution == 'fedora':
-                host.run_test('dnf install lshw -y')
+                host.run_test('dnf install lshw -y >/dev/null')
 
             nic_name = host.check_output('lshw -C network')
             nic_driver = host.check_output('lshw -C network | grep "driver="')


### PR DESCRIPTION
We believe this can avoid overloading stdout and resulting in unexpected -1
return code (testinfra module issue).