### PR TITLE
Migrated test_check_waagent_log from os-tests.

### DIFF
--- a/lib/test_lib.py
+++ b/lib/test_lib.py
@@ -135,3 +135,34 @@ def compare_local_and_remote_file(host,
         host.run(f'rm -rf {tmp_path}')
 
         return result.exit_status == 0
+
+
+def filter_host_log_file_by_keywords(host,
+                                     log_file,
+                                     log_levels,
+                                     keywords,
+                                     exclude_mode=False):
+    log_levels_regex = '|'.join(log_levels)
+    keywords_regex = '|'.join(keywords)
+
+    print(f'Filtering {log_file} log file...')
+
+    if exclude_mode:
+        search_opt = '-vE'
+        print('(Exclude mode set to True. Keywords will be used for invert match)')
+    else:
+        search_opt = '-E'
+
+    with host.sudo():
+        result = host.run('grep -iE "{}" "{}" | grep {} "{}"'.format(log_levels_regex,
+                                                                     log_file,
+                                                                     search_opt,
+                                                                     keywords_regex))
+        if result.rc == 0:
+            print(f'Logs found:\n{result.stdout}')
+            return result.stdout
+        else:
+            print('No logs found.')
+            print(result.stderr)
+
+        return None

--- a/test_suite/cloud/test_azure.py
+++ b/test_suite/cloud/test_azure.py
@@ -224,3 +224,25 @@ class TestsAzure:
         with host.sudo():
             for service in service_list:
                 assert host.service(service).is_running
+
+    @pytest.mark.run_on(['all'])
+    def test_waagent_log(self, host):
+        """
+        Verify no err/fail/warn/trace in /var/log/waagent.log
+        """
+        file_to_check = '/var/log/waagent.log'
+        log_levels = ['err', 'fail', 'warn', 'trace']
+        ignore_list = [
+            'preferred',
+            'Dhcp client is not running',
+            'Move rules file 70-persistent-net.rules',
+            'UpdateGSErrors: 0'
+        ]
+
+        logs_found = test_lib.filter_host_log_file_by_keywords(host,
+                                                               file_to_check,
+                                                               log_levels,
+                                                               ignore_list,
+                                                               exclude_mode=True)
+        assert logs_found is None, \
+            f'Unexpected logs found in {file_to_check}'


### PR DESCRIPTION
Also added a test_util function to filter log files. It will be useful
for similar test cases (in os-tests there was also an auxiliary function
for that).