### PR TITLE
Migrated kdump-related test cases, from os-tests.

### DIFF
--- a/cloud/terraform/aws_config_builder.py
+++ b/cloud/terraform/aws_config_builder.py
@@ -55,7 +55,7 @@ class AWSConfigBuilder(BaseConfigBuilder):
 
     def __new_aws_instance(self, instance):
         if not instance['instance_type']:
-            instance['instance_type'] = 't2.micro'
+            instance['instance_type'] = 't3.medium'
 
         name_tag = instance['name'].replace('.', '-')
         name = self.create_resource_name([name_tag])

--- a/cloud/terraform/gcloud_config_builder.py
+++ b/cloud/terraform/gcloud_config_builder.py
@@ -84,7 +84,7 @@ class GCloudConfigBuilder(BaseConfigBuilder):
 
     def __new_gcloud_instance(self, instance):
         if not instance['instance_type']:
-            instance['instance_type'] = 'e2-micro'
+            instance['instance_type'] = 'c2d-highcpu-2'
 
         # Google instance names must match the following regex: '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'
         formatted_name = instance['name'].replace('.', '-').replace('_', '-')


### PR DESCRIPTION
Also changed the default instance type for AWS and GCP.
If the instance has 1GB or less, kdump serive fails to start
due to memory allocation issues.
Test names from os-tests:
- test_check_kdump_configuration
- test_check_kdump_status