### PR TITLE
test_timezone_is_utc only applies to aws

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,8 +47,8 @@ aws:
     - |
       sudo podman run \
       -a stdout -a stderr \
-      -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
-      -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+      -e AWS_ACCESS_KEY_ID="${V2_AWS_ACCESS_KEY_ID}" \
+      -e AWS_SECRET_ACCESS_KEY="${V2_AWS_SECRET_ACCESS_KEY}" \
       -e AWS_REGION="${AWS_REGION}" \
       -v ./:/tmp:Z \
       "${QUAY_IO_CONTAINER_URL}":"${CI_COMMIT_REF_SLUG}" \
@@ -62,8 +62,8 @@ azure:
     - |
       sudo podman run \
       -a stdout -a stderr \
-      -e ARM_CLIENT_ID="${AZURE_CLIENT_ID}" \
-      -e ARM_CLIENT_SECRET="${AZURE_CLIENT_SECRET}" \
+      -e ARM_CLIENT_ID="${V2_AZURE_CLIENT_ID}" \
+      -e ARM_CLIENT_SECRET="${V2_AZURE_CLIENT_SECRET}" \
       -e ARM_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
       -e ARM_TENANT_ID="${AZURE_TENANT_ID}" \
       -v ./:/tmp:Z \

--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -608,6 +608,14 @@ class TestsAWS:
             assert int(host.check_output('rpm -q gpg-pubkey | wc -l')) == num_of_gpg_keys, \
                 f'There should be {num_of_gpg_keys} gpg key(s) installed'
 
+    @pytest.mark.run_on(['all'])
+    def test_timezone_is_utc(self, host):
+        """
+        Check that the default timezone is set to UTC.
+        BugZilla 1187669
+        """
+        assert 'UTC' in host.check_output('date'), 'Unexpected timezone. Expected to be UTC'
+
 
 # TODO: Almost all these tests are cloud-agnostic
 @pytest.mark.order(2)

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -214,14 +214,6 @@ class TestsGeneric:
         assert host.file('/etc/shells').contains('/bin/bash'), \
             '/bin/bash is not declared in /etc/shells'
 
-    @pytest.mark.run_on(['all'])
-    def test_timezone_is_utc(self, host):
-        """
-        Check that the default timezone is set to UTC.
-        BugZilla 1187669
-        """
-        assert 'UTC' in host.check_output('date'), 'Unexpected timezone. Expected to be UTC'
-
     @pytest.mark.run_on(['rhel'])
     def test_grub_config(self, host):
         grub2_file = '/boot/grub2/grubenv'


### PR DESCRIPTION
Check bugzilla in test docstring. This test only applies to aws not
other clouds (at least it seems so)