### PR TITLE
test_suite: crashkernel_is_enabled bug

### DIFF
--- a/lib/console_lib.py
+++ b/lib/console_lib.py
@@ -9,3 +9,11 @@ def print_divider(text):
     color_print('-' * divider_length)
     color_print(' ' * free_spaces + text)
     color_print('-' * divider_length)
+
+
+def print_debug(vars):
+    vars_string = '\n----------DEBUG----------'
+    for key, value in vars.items():
+        vars_string += f'\n - {key} = {value}'
+    vars_string += '\n----------DEBUG----------'
+    return vars_string

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -2,6 +2,7 @@ import os
 import pytest
 
 from lib import test_lib
+from lib import console_lib
 
 
 @pytest.mark.order(1)
@@ -68,11 +69,17 @@ class TestsGeneric:
             expected_content = 'crashkernel=auto'
         else:
             with host.sudo():
-                expected_content = host.check_output('kdumpctl showmem 2>&1 | sed -E "s/.*Reserved ([0-9]*).*/\1/"')
+                expected_content = str(host.check_output('kdumpctl showmem 2>&1 | grep -oP "[0-9]*"'))
 
         with host.sudo():
+            print(console_lib.print_debug({"expected_content": expected_content,
+                                           "/proc/cmdline content": host.file("/proc/cmdline").content_string,
+                                           "kdumpctl showmem": host.check_output("kdumpctl showmem 2>&1")}))
+
             assert host.file('/proc/cmdline').contains(expected_content), \
-                f'crashkernel must be enabled {expected_content}\n - {host.file("/proc/cmdline").content_string}\n - {host.check_output("kdumpctl showmem 2>&1")}'
+                'crashkernel must be enabled'
+
+            # {expected_content}\n - {host.file("/proc/cmdline").content_string}\n - {host.check_output("kdumpctl showmem 2>&1")}
 
     @pytest.mark.run_on(['all'])
     def test_cpu_flags_are_correct(self, host, instance_data):


### PR DESCRIPTION
crashkernel_is_enabled_rhel is failing because the configuration changed. to avoid having to maintain the test everytime the config changes, check `kdumpctl showmem` instead