### PR TITLE
test_suite: fix test_pwquality_conf for fedora

### DIFF
--- a/test_suite/cloud/test_azure.py
+++ b/test_suite/cloud/test_azure.py
@@ -211,6 +211,9 @@ class TestsAzure:
             'ucredit = 0',
         ]
 
+        if host.system_info.distribution == 'fedora':
+            expected_settings[2] = 'minclass = 0'
+
         with host.sudo():
             debug = {"pwquality.conf": host.file(file_to_check).content_string}
             for setting in expected_settings:


### PR DESCRIPTION
fedora has different setting for `minclass`. Add this exception to the test