### PR TITLE
test_suite: enable nightly failing tests

### DIFF
--- a/test_suite/cloud/test_azure.py
+++ b/test_suite/cloud/test_azure.py
@@ -83,12 +83,6 @@ class TestsAzure:
         BugZilla 1645772
         nouveau,lbm-nouveau,floppy,skx_edac,intel_cstate should be disabled
         """
-        # ---- To be removed by CLOUDX-211 ----
-        product_release_version = float(host.system_info.release)
-        if host.system_info.distribution == 'rhel' and (product_release_version == 9.1 or product_release_version == 8.7):
-            pytest.skip("Temporarily skip test due to failing nightlies (CLOUDX-211)")
-        # -------------------------------------
-
         file_pattern = '/lib/modprobe.d/blacklist-*.conf'
 
         blacklist = ['nouveau', 'lbm-nouveau', 'floppy', 'amdgpu']
@@ -207,12 +201,6 @@ class TestsAzure:
         """
         Check file /etc/security/pwquality.conf
         """
-        # ---- To be removed by CLOUDX-211 ----
-        product_release_version = float(host.system_info.release)
-        if host.system_info.distribution == 'rhel' and (product_release_version == 9.1 or product_release_version == 8.7):
-            pytest.skip("Temporarily skip test due to failing nightlies (CLOUDX-211)")
-        # -------------------------------------
-
         file_to_check = '/etc/security/pwquality.conf'
         expected_settings = [
             'dcredit = 0',
@@ -255,12 +243,6 @@ class TestsAzure:
         """
         Check that the expected packages are installed.
         """
-        # ---- To be removed by CLOUDX-211 ----
-        product_release_version = float(host.system_info.release)
-        if host.system_info.distribution == 'rhel' and (product_release_version == 9.1 or product_release_version == 8.7):
-            pytest.skip("Temporarily skip test due to failing nightlies (CLOUDX-211)")
-        # -------------------------------------
-
         wanted_pkgs = [
             'yum-utils', 'redhat-release-eula', 'cloud-init',
             'tar', 'rsync', 'NetworkManager', 'cloud-utils-growpart', 'gdisk',

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -67,11 +67,6 @@ class TestsGeneric:
         """
         product_release_version = float(host.system_info.release)
 
-        # ---- To be removed by CLOUDX-211 ----
-        if host.system_info.distribution == 'rhel' and (product_release_version == 9.1 or product_release_version == 8.7):
-            pytest.skip("Temporarily skip test due to failing nightlies (CLOUDX-211)")
-        # -------------------------------------
-
         if product_release_version < 9.0:
             expected_content = 'crashkernel=auto'
         else:
@@ -448,12 +443,6 @@ class TestsNetworking:
         BugZilla 1822853
         >=8.5: check NetworkManager-cloud-setup is installed and nm-cloud-setup.timer is setup for Azure and enabled
         """
-        # ---- To be removed by CLOUDX-211 ----
-        product_release_version = float(host.system_info.release)
-        if host.system_info.distribution == 'rhel' and (product_release_version == 9.1 or product_release_version == 8.7):
-            pytest.skip("Temporarily skip test due to failing nightlies (CLOUDX-211)")
-        # -------------------------------------
-
         cloud_setup_base_path = '/usr/lib/systemd/system/nm-cloud-setup.service.d/'
         files_and_configs_by_cloud = {
             'aws': {
@@ -676,12 +665,6 @@ class TestsKdump:
         """
         Verify that kdump is enabled
         """
-        # ---- To be removed by CLOUDX-211 ----
-        product_release_version = float(host.system_info.release)
-        if host.system_info.distribution == 'rhel' and (product_release_version == 9.1 or product_release_version == 8.7):
-            pytest.skip("Temporarily skip test due to failing nightlies (CLOUDX-211)")
-        # -------------------------------------
-
         with host.sudo():
             assert 'Kdump is operational' in host.check_output('kdumpctl status 2>&1'), \
                 'Kdump is not operational'


### PR DESCRIPTION
Failing tests where disabled so we could debug them in CIV repo instead of osbuild-composer (CLOUDX-211). Enable them and solve them