### PR TITLE
Fix test_kdump_status test case.

### DIFF
--- a/cloud/terraform/aws_config_builder.py
+++ b/cloud/terraform/aws_config_builder.py
@@ -55,7 +55,9 @@ class AWSConfigBuilder(BaseConfigBuilder):
 
     def __new_aws_instance(self, instance):
         if not instance['instance_type']:
-            instance['instance_type'] = 't3.medium'
+            # CIV will assume the AMI is x64. For ARM, the instance_type must be manually specified in resources.json
+            # This does not apply to the automation in Jenkins, since we parse the pub task and get the arch from there
+            instance['instance_type'] = 't3.large'
 
         name_tag = instance['name'].replace('.', '-')
         name = self.create_resource_name([name_tag])


### PR DESCRIPTION
This test case is sometimes failing due to lack of RAM in the running instance. By setting an instance type with more resources, this should be fixed. This test also indirectly fixed test_no_fail_service test case, since this latter one is also failing when kdump did not work as expected.