### PR TITLE
Fix test_network_manager_cloud_setup

### DIFF
--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -586,7 +586,7 @@ class TestsNetworking:
                 f'Unexpected device name. Expected: "{device_name}"'
 
     @pytest.mark.run_on(['rhel'])
-    @pytest.mark.exclude_on(['rhel7.9', 'rhel8.4'])
+    @pytest.mark.exclude_on(['<rhel8.5'])
     def test_network_manager_cloud_setup(self, host, instance_data):
         """
         BugZilla 1822853
@@ -606,7 +606,7 @@ class TestsNetworking:
 
         # EXDSP-813
         if instance_data['cloud'] == 'azure' and float(host.system_info.release) == 8.5:
-            pytest.skip("There is a known issue in RHEL 8.5 Azure images and won't be fixed.")
+            pytest.skip("There is a known issue affecting RHEL 8.5 on Azure images and won't be fixed (EXDSP-813).")
 
         with host.sudo():
             assert host.package('NetworkManager-cloud-setup').is_installed, \


### PR DESCRIPTION
This test case was being run on RHEL lower than 8.4 since the exclusion logic was only applying to RHEL 8.4 This needs to be excluded in ANY RHEL version lover than 8.5.