### PR TITLE
Add a JSON report as part of the artifacts generated by the tool.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pytest-order==1.0.1
 pytest-xdist==3.1.0
 pytest-rerunfailures==11.0
 pytest-html==3.2.0
+pytest-json-report==1.5.0
 sshconf==0.2.5
 flake8==6.0.0
 argparse==1.4.0

--- a/test/test_suite_runner.py
+++ b/test/test_suite_runner.py
@@ -49,13 +49,15 @@ class TestSuiteRunner:
           f'--connection={test_connection} '
           f'--ssh-config {test_ssh_config} --junit-xml {test_output_filepath} '
           f'--html {test_output_filepath.replace("xml", "html")} '
-          f'--self-contained-html'),
+          f'--self-contained-html '
+          f'--json-report --json-report-file={test_output_filepath.replace("xml", "json")}'),
          (test_filter, test_marker, False, False,
           'py.test path1 path2 --hosts=user1@host1,user2@host2 '
           f'--connection={test_connection} '
           f'--ssh-config {test_ssh_config} --junit-xml {test_output_filepath} '
           f'--html {test_output_filepath.replace("xml", "html")} '
           f'--self-contained-html '
+          f'--json-report --json-report-file={test_output_filepath.replace("xml", "json")} '
           f'-k "{test_filter}" '
           f'-m "{test_marker}"'),
          (None, None, False, True,
@@ -64,6 +66,7 @@ class TestSuiteRunner:
           f'--ssh-config {test_ssh_config} --junit-xml {test_output_filepath} '
           f'--html {test_output_filepath.replace("xml", "html")} '
           f'--self-contained-html '
+          f'--json-report --json-report-file={test_output_filepath.replace("xml", "json")} '
           f'--numprocesses={len(test_instances)} --maxprocesses=40 '
           '--only-rerun="socket.timeout|refused|ConnectionResetError|TimeoutError|SSHException|NoValidConnectionsError" '
           '--reruns 3 --reruns-delay 5'),
@@ -73,6 +76,7 @@ class TestSuiteRunner:
           f'--ssh-config {test_ssh_config} --junit-xml {test_output_filepath} '
           f'--html {test_output_filepath.replace("xml", "html")} '
           f'--self-contained-html '
+          f'--json-report --json-report-file={test_output_filepath.replace("xml", "json")} '
           f'--numprocesses={len(test_instances)} --maxprocesses=40 '
           '--only-rerun="socket.timeout|refused|ConnectionResetError|TimeoutError|SSHException|NoValidConnectionsError" '
           '--reruns 3 --reruns-delay 5 '

--- a/test_suite/suite_runner.py
+++ b/test_suite/suite_runner.py
@@ -56,6 +56,7 @@ class SuiteRunner:
             f'--junit-xml {output_filepath}',
             f'--html {output_filepath.replace("xml", "html")}',
             '--self-contained-html',
+            f'--json-report --json-report-file={output_filepath.replace("xml", "json")}'
         ]
 
         if test_filter:


### PR DESCRIPTION
This is a previous step to unblock other use cases to process test report data such as the CIV Report Analyzer tool we are developing right now.