### PR TITLE
Add new variable with CIV options

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,7 +160,8 @@ IB-aws:
   extends: .IB_tests
   script:
     - schutzbot/deploy.sh
-    - ARTIFACTS=/tmp/ bash /usr/libexec/tests/osbuild-composer/aws.sh
+    - export ARTIFACTS=/tmp/ CIV_OPTIONS=("-r /tmp/resource-file.json" "-d" "-o /tmp/report.xml" "-m 'not pub'")
+    - bash /usr/libexec/tests/osbuild-composer/aws.sh
   parallel:
     matrix:
       - *fedora_runners
@@ -174,7 +175,8 @@ IB-azure:
   extends: .IB_tests
   script:
     - schutzbot/deploy.sh
-    - ARTIFACTS=/tmp/ bash /usr/libexec/tests/osbuild-composer/azure.sh
+    - export ARTIFACTS=/tmp/ CIV_OPTIONS=("-r /tmp/resource-file.json" "-d" "-o /tmp/report.xml" "-m 'not pub'")
+    - bash /usr/libexec/tests/osbuild-composer/azure.sh
   parallel:
     matrix:
       - *fedora_runners


### PR DESCRIPTION
In order to use different options when running aws.sh from CIV CI, we are now using a variable to specify this. This is done to start the work for CLOUDX-345