### PR TITLE
Skip subscription manager test cases in RHEL lower than 8.3

### DIFF
--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -375,6 +375,7 @@ class TestsServices:
 
 @pytest.mark.pub
 @pytest.mark.run_on(['rhel'])
+@pytest.mark.exclude_on(['<rhel8.3'])
 class TestsSubscriptionManager:
     def test_subscription_manager_auto(self, host):
         """
@@ -437,7 +438,7 @@ class TestsSubscriptionManager:
     def test_subscription_manager_auto_config(self, host):
         """
         BugZilla: 1932802, 1905398
-        Verify auto_registration is enabled in the image
+        Verify that auto_registration is enabled in the image
         """
         expected_config = [
             'auto_registration = 1',


### PR DESCRIPTION
The test cases that are included in this fix:
- test_subscription_manager_auto
- test_subscription_manager_auto_config