### PR TITLE
Modify timeout for ssh

### DIFF
--- a/cloud/terraform/terraform_controller.py
+++ b/cloud/terraform/terraform_controller.py
@@ -28,7 +28,7 @@ class TerraformController:
         self.wait_for_all_instances_ssh_up()
 
     def wait_for_all_instances_ssh_up(self):
-        seconds_to_wait = 120
+        seconds_to_wait = 180
         instances = self.get_instances()
 
         threads = []


### PR DESCRIPTION
Since adding ap-southeast-4 regions, those instances are timing out. Trying to see if this is the reason