### PR TITLE
Support tagging of Google Cloud resources

### DIFF
--- a/cloud/terraform/base_config_builder.py
+++ b/cloud/terraform/base_config_builder.py
@@ -12,6 +12,7 @@ class BaseConfigBuilder:
     }
 
     resource_name_prefix = 'civ'
+    resource_tags_key = 'tags'
 
     def __init__(self, resources_dict, ssh_key_path, config):
         self.resources_dict = resources_dict
@@ -46,7 +47,9 @@ class BaseConfigBuilder:
     def get_random_numbers(self):
         return f'{random.randrange(1, 10 ** 5):03}'
 
-    def add_tags(self, config_dict, resource, tags_key="tags"):
+    def add_tags(self, config_dict, resource):
+        tags_key = self.resource_tags_key
+
         if config_dict["tags"]:
             if tags_key in resource:
                 resource[tags_key] = {**resource[tags_key], **config_dict["tags"]}

--- a/cloud/terraform/gcloud_config_builder.py
+++ b/cloud/terraform/gcloud_config_builder.py
@@ -7,6 +7,8 @@ class GCloudConfigBuilder(BaseConfigBuilder):
 
     default_ssh_user = 'user'
 
+    resource_tags_key = 'labels'
+
     ssh_enabled_tag = 'ssh-enabled'
 
     def __init__(self, resources_dict, ssh_key_path, config):
@@ -99,6 +101,8 @@ class GCloudConfigBuilder(BaseConfigBuilder):
             }
         }
 
+        self.add_tags(self.config, boot_disk['initialize_params'])
+
         network_interface = {
             'network': instance['google_compute_network'],
             'access_config': {}
@@ -115,7 +119,6 @@ class GCloudConfigBuilder(BaseConfigBuilder):
             'username': username,
         }
 
-        # TODO: Enable tags from config file
         new_instance = {
             'name': name,
             'machine_type': instance['instance_type'],
@@ -129,4 +132,5 @@ class GCloudConfigBuilder(BaseConfigBuilder):
             ]
         }
 
+        self.add_tags(self.config, new_instance)
         self.resources_tf['resource']['google_compute_instance'][name] = new_instance


### PR DESCRIPTION
Google Cloud uses labels instead of tags.