### PR TITLE
Improved logic when testing subscription manager.

### DIFF
--- a/main/civ_report_analyzer.py
+++ b/main/civ_report_analyzer.py
@@ -156,7 +156,9 @@ def get_analysis_as_spreadsheet_table(summary, analysis, test_environment):
     default_rerun_value = 'FALSE'
     default_delimiter = '\t'
 
-    jenkins_url = '=HYPERLINK("{0}/Report", "{1}")'.format(test_environment['BUILD_URL'], 'Jenkins Report')
+    jenkins_url = 'Jenkins Report'
+    if 'BUILD_URL' in test_environment:
+        jenkins_url = '=HYPERLINK("{0}/Report", "{1}")'.format(test_environment['BUILD_URL'], 'Jenkins Report')
 
     summary_lines = [
         "\t".join(['Total passed:', f"{summary['passed_total']}", '', '', '', 'Pub Task']),


### PR DESCRIPTION
This logic is now checking if the AWS region of the running instance is actually supported or not. The list of supported and unsupported regions is in a Google Spreadsheet created by the RHUI Team: https://docs.google.com/spreadsheets/d/15bcP0a9fBaxHVbk6tXiBL8Hn5fLjkHx9GjNf06ctISI/