### PR TITLE
Improve CIV performance for automation

### DIFF
--- a/test/test_suite_runner.py
+++ b/test/test_suite_runner.py
@@ -45,14 +45,14 @@ class TestSuiteRunner:
     @pytest.mark.parametrize(
         'test_filter, test_marker, test_debug, test_parallel, expected_command_string',
         [(None, None, False, False,
-          'py.test path1 path2 --hosts=user1@host1,user2@host2 '
+          'pytest path1 path2 --hosts=user1@host1,user2@host2 '
           f'--connection={test_connection} '
           f'--ssh-config {test_ssh_config} --junit-xml {test_output_filepath} '
           f'--html {test_output_filepath.replace("xml", "html")} '
           f'--self-contained-html '
           f'--json-report --json-report-file={test_output_filepath.replace("xml", "json")}'),
          (test_filter, test_marker, False, False,
-          'py.test path1 path2 --hosts=user1@host1,user2@host2 '
+          'pytest path1 path2 --hosts=user1@host1,user2@host2 '
           f'--connection={test_connection} '
           f'--ssh-config {test_ssh_config} --junit-xml {test_output_filepath} '
           f'--html {test_output_filepath.replace("xml", "html")} '
@@ -61,23 +61,23 @@ class TestSuiteRunner:
           f'-k "{test_filter}" '
           f'-m "{test_marker}"'),
          (None, None, False, True,
-          'py.test path1 path2 --hosts=user1@host1,user2@host2 '
+          'pytest path1 path2 --hosts=user1@host1,user2@host2 '
           f'--connection={test_connection} '
           f'--ssh-config {test_ssh_config} --junit-xml {test_output_filepath} '
           f'--html {test_output_filepath.replace("xml", "html")} '
           f'--self-contained-html '
           f'--json-report --json-report-file={test_output_filepath.replace("xml", "json")} '
-          f'--numprocesses={len(test_instances)} --maxprocesses=40 '
+          f'--numprocesses={len(test_instances)} --maxprocesses=162 '
           '--only-rerun="socket.timeout|refused|ConnectionResetError|TimeoutError|SSHException|NoValidConnectionsError" '
           '--reruns 3 --reruns-delay 5'),
          (None, None, True, True,
-          'py.test path1 path2 --hosts=user1@host1,user2@host2 '
+          'pytest path1 path2 --hosts=user1@host1,user2@host2 '
           f'--connection={test_connection} '
           f'--ssh-config {test_ssh_config} --junit-xml {test_output_filepath} '
           f'--html {test_output_filepath.replace("xml", "html")} '
           f'--self-contained-html '
           f'--json-report --json-report-file={test_output_filepath.replace("xml", "json")} '
-          f'--numprocesses={len(test_instances)} --maxprocesses=40 '
+          f'--numprocesses={len(test_instances)} --maxprocesses=162 '
           '--only-rerun="socket.timeout|refused|ConnectionResetError|TimeoutError|SSHException|NoValidConnectionsError" '
           '--reruns 3 --reruns-delay 5 '
           '-v')]

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -761,7 +761,7 @@ class TestsKdump:
         QE: xiawu@redhat.com
         """
         with host.sudo():
-            print(f' - kexec-tools version: {host.run("rpm -qa | grep kexec-tools")}')
+            print(f' - kexec-tools version: {host.run("rpm -qa | grep kexec-tools").stdout}')
 
             if 'Kdump is operational' not in host.run('kdumpctl status 2>&1').stdout:
                 print(f' - kdumpctl showmem: {host.run("kdumpctl showmem").stdout}')

--- a/test_suite/suite_runner.py
+++ b/test_suite/suite_runner.py
@@ -2,7 +2,7 @@ import os
 
 
 class SuiteRunner:
-    max_processes = 40  # based on the number of threads used by ami-val
+    max_processes = 162  # This is the maximum amount of images we have successfully tested in parallel (AWS)
 
     # Rerun failed tests in case ssh times out or connection is refused by host
     rerun_failing_tests_regex = '|'.join([
@@ -48,7 +48,7 @@ class SuiteRunner:
         all_hosts = self.get_all_instances_hosts_with_users()
 
         command_with_args = [
-            'py.test',
+            'pytest',
             ' '.join(self.get_test_suite_paths()),
             f'--hosts={all_hosts}',
             f'--connection={self.connection_backend}',


### PR DESCRIPTION
This PR increases the maximum number of concurrent threads for testing in parallel. Before it was limited to 40 but we usually test more than 160 images at the same time in our automation, so it is taking 1 hour in total.

With this change, based on the latest testing, we are reducing suite runner execution time by ~64%. So, it is 2/3 faster than before.

However we are still limited by Terraform during deployment and even though we will increase the parallelism value (in the Jenkins pipeline), we may be still limited by the cloud provider's API calls limit or the SDK implementation that Terraform uses in the backend.