### PR TITLE
Fixed dependencies issues with PyYAML and pytest.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-pytest==7.3.1
+PyYAML==5.3.1
+pytest==7.4.0
 pytest-mock==3.10.0
 pytest-cov==4.0.0
-pytest-testinfra==7.0.0
+pytest-testinfra==8.1.0
 pytest-order==1.1.0
 pytest-xdist==3.2.1
 pytest-rerunfailures==11.1.2


### PR DESCRIPTION
In the past days there was a bug affecting pytest. This was reported and tracked here:

* https://github.com/yaml/pyyaml/issues/724

The proposed solution was to downgrade PyYAML to 5.3.1 until it was resolved. Now this issue is fixed in PyYAML, however there are still no updates from pytest, which is currently in v7.4.0 (last update in June 23 2023).

Until they update this in next release, we will force PyYAML 5.3.1 to be installed before pytest in our project dependencies.

In this PR we also take the opportunity to update pytest-testinfra to benefit from stability and performance improvements.