### PR TITLE
Fixed version comparisons in all the test suites and conftest.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==5.3.1
-pytest==7.4.0
+pytest~=7.4.3
 pytest-mock==3.10.0
 pytest-cov==4.0.0
 pytest-testinfra==8.1.0
@@ -15,3 +15,4 @@ py==1.11.0
 paramiko==3.1.0
 awscli==1.27.119
 requests==2.28.1
+packaging==23.2

--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -116,10 +116,10 @@ class TestsAWS:
         assert host.service(
             auditd_service).is_running, f'{auditd_service} expected to be running'
 
-        rhel_version = version.parse(host.system_info.release)
-        if rhel_version >= version.parse('8.6'):
+        system_release = version.parse(host.system_info.release)
+        if system_release >= version.parse('8.6'):
             checksums = checksums_by_version['8.6+']
-        elif rhel_version >= version.parse('8.0'):
+        elif system_release >= version.parse('8.0'):
             checksums = checksums_by_version['8.0+']
         else:
             checksums = checksums_by_version['7.0+']
@@ -199,13 +199,13 @@ class TestsAWS:
             'firewalld', 'biosdevname', 'plymouth', 'iprutils', 'rng-tools', 'qemu-guest-agent'
         ]
 
-        product_version = version.parse(host.system_info.release)
+        system_release = version.parse(host.system_info.release)
 
         # BugZilla 1888695
-        if version.parse('8.3') > product_version >= version.parse('8.0'):
+        if version.parse('8.3') > system_release >= version.parse('8.0'):
             unwanted_pkgs.remove('rng-tools')
 
-        if product_version < version.parse('8.5'):
+        if system_release < version.parse('8.5'):
             unwanted_pkgs.remove('qemu-guest-agent')
 
         if test_lib.is_rhel_sap(host):
@@ -245,11 +245,11 @@ class TestsAWS:
             'grub2', 'tar', 'rsync', 'chrony'
         ]
 
-        product_version = version.parse(host.system_info.release)
-        if product_version >= version.parse('8.5'):
+        system_release = version.parse(host.system_info.release)
+        if system_release >= version.parse('8.5'):
             required_pkgs.append('NetworkManager-cloud-setup')
 
-        if version.parse('8.3') > product_version >= version.parse('8.0'):
+        if version.parse('8.3') > system_release >= version.parse('8.0'):
             required_pkgs.append('rng-tools')
 
         if test_lib.is_rhel_sap(host):
@@ -275,14 +275,14 @@ class TestsAWS:
             required_pkgs.append('tuned-profiles-sap-hana')
 
             # CLOUDX-367
-            if product_version >= version.parse('8.6'):
+            if system_release >= version.parse('8.6'):
                 required_pkgs.append('ansible-core')
             else:
                 required_pkgs.append('ansible')
 
         # CLOUDX-451
-        if product_version.major == 9 and product_version.minor >= 3 or \
-                product_version.major == 8 and product_version.minor >= 9:
+        if system_release.major == 9 and system_release.minor >= 3 or \
+                system_release.major == 8 and system_release.minor >= 9:
             if host.system_info.arch != 'aarch64':
                 # Legacy BIOS boot mode related package
                 required_pkgs.append('grub2-pc')
@@ -293,7 +293,7 @@ class TestsAWS:
         if test_lib.is_rhel_high_availability(host):
             required_pkgs.extend(['fence-agents-all', 'pacemaker', 'pcs'])
 
-        if product_version < version.parse('8.0'):
+        if system_release < version.parse('8.0'):
             required_pkgs = required_pkgs_v7
 
         missing_pkgs = [pkg for pkg in required_pkgs if not host.package(pkg).is_installed]
@@ -665,9 +665,9 @@ class TestsAWS:
 
         path_to_check = '/sys/firmware/efi'
 
-        product_version = version.parse(host.system_info.release)
-        if product_version.major == 9 and product_version.minor >= 3 or \
-                product_version.major == 8 and product_version.minor >= 9:
+        system_release = version.parse(host.system_info.release)
+        if system_release.major == 9 and system_release.minor >= 3 or \
+                system_release.major == 8 and system_release.minor >= 9:
             with host.sudo():
                 assert host.file(path_to_check).exists, \
                     f'{path_to_check} is expected to exist in EFI-booted images.'

--- a/test_suite/cloud/test_azure.py
+++ b/test_suite/cloud/test_azure.py
@@ -128,9 +128,9 @@ class TestsAzure:
             9: 'grub_rhel9'
         }
 
-        rhel_major_version = version.parse(host.system_info.release).major
+        system_release_major_version = version.parse(host.system_info.release).major
 
-        local_file = 'data/azure/{}'.format(grub_files_by_rhel_major_version[rhel_major_version])
+        local_file = 'data/azure/{}'.format(grub_files_by_rhel_major_version[system_release_major_version])
         remote_file = '/etc/default/grub'
 
         assert test_lib.compare_local_and_remote_file(host, local_file, remote_file), \
@@ -258,8 +258,8 @@ class TestsAzure:
             'hypervkvpd', 'hyperv-daemons-license', 'hypervfcopyd', 'hypervvssd', 'hyperv-daemons'
         ]
 
-        product_version = version.parse(host.system_info.release)
-        if product_version < version.parse('8.0'):
+        system_release = version.parse(host.system_info.release)
+        if system_release < version.parse('8.0'):
             wanted_pkgs.append('dhclient')
         else:
             wanted_pkgs.extend(['insights-client', 'dhcp-client'])

--- a/test_suite/cloud/test_azure.py
+++ b/test_suite/cloud/test_azure.py
@@ -1,8 +1,10 @@
 import json
-import pytest
 
-from lib import test_lib
+import pytest
+from packaging import version
+
 from lib import console_lib
+from lib import test_lib
 
 
 @pytest.fixture
@@ -64,7 +66,7 @@ class TestsAzure:
         file_to_check = '/etc/sysconfig/authconfig'
 
         with host.sudo():
-            if float(host.system_info.release) < 8.0:
+            if version.parse(host.system_info.release) < version.parse('8.0'):
                 # In RHEL-7, check authconfig content
                 local_file = 'data/azure/authconfig'
 
@@ -85,7 +87,7 @@ class TestsAzure:
 
         blocklist = ['nouveau', 'lbm-nouveau', 'floppy', 'amdgpu']
 
-        if float(host.system_info.release) < 9.0:
+        if version.parse(host.system_info.release) < version.parse('9.0'):
             blocklist.extend(['skx_edac', 'intel_cstate'])
 
         with host.sudo():
@@ -126,7 +128,7 @@ class TestsAzure:
             9: 'grub_rhel9'
         }
 
-        rhel_major_version = int(float(host.system_info.release))
+        rhel_major_version = version.parse(host.system_info.release).major
 
         local_file = 'data/azure/{}'.format(grub_files_by_rhel_major_version[rhel_major_version])
         remote_file = '/etc/default/grub'
@@ -150,7 +152,7 @@ class TestsAzure:
             'hv_vmbus'
         ]
 
-        if float(host.system_info.release) < 9.0:
+        if version.parse(host.system_info.release) < version.parse('9.0'):
             hyperv_driver_list.append('hyperv_fb')
         else:
             hyperv_driver_list.append('hyperv_drm')
@@ -192,7 +194,7 @@ class TestsAzure:
         with host.sudo():
             base_command = 'fdisk -l | grep "Linux LVM"'
 
-            if float(host.system_info.release) < 8.0:
+            if version.parse(host.system_info.release) < version.parse('8.0'):
                 cmd = f'{base_command} | awk "{{print $4}}"'
             else:
                 cmd = f'{base_command} | awk "{{print $5}}"'
@@ -256,8 +258,8 @@ class TestsAzure:
             'hypervkvpd', 'hyperv-daemons-license', 'hypervfcopyd', 'hypervvssd', 'hyperv-daemons'
         ]
 
-        product_version = float(host.system_info.release)
-        if product_version < 8.0:
+        product_version = version.parse(host.system_info.release)
+        if product_version < version.parse('8.0'):
             wanted_pkgs.append('dhclient')
         else:
             wanted_pkgs.extend(['insights-client', 'dhcp-client'])
@@ -284,7 +286,7 @@ class TestsAzure:
         Check /etc/cloud/cloud.cfg.d/05_logging.cfg
         * For RHEL-7 it is 06_logging_override.cfg
         """
-        if float(host.system_info.release) < 8.0:
+        if version.parse(host.system_info.release) < version.parse('8.0'):
             file_to_check = '/etc/cloud/cloud.cfg.d/06_logging_override.cfg'
             local_file = 'data/azure/06_logging_override.cfg'
         else:

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -56,9 +56,9 @@ class TestsGeneric:
         """
         Check that crashkernel is enabled in image.
         """
-        product_release_version = version.parse(host.system_info.release)
+        system_release = version.parse(host.system_info.release)
 
-        if product_release_version < version.parse('9.0'):
+        if system_release < version.parse('9.0'):
             expected_content = 'crashkernel=auto'
         else:
             with host.sudo():
@@ -135,9 +135,9 @@ class TestsGeneric:
         BugZilla 1938930
         Issue RHELPLAN-60817
         """
-        product_version = version.parse(host.system_info.release)
+        system_release = version.parse(host.system_info.release)
 
-        if product_version < version.parse('8.0'):
+        if system_release < version.parse('8.0'):
             rpm_to_check = 'redhat-release-server'
         else:
             rpm_to_check = 'redhat-release'
@@ -147,7 +147,7 @@ class TestsGeneric:
 
             cert_version = host.check_output('rct cat-cert /etc/pki/product-default/*.pem | grep Version')
 
-            assert f'Version: {product_version}' in cert_version, \
+            assert f'Version: {system_release}' in cert_version, \
                 'Inconsistent version in pki certificate'
 
     @pytest.mark.run_on(['all'])
@@ -182,7 +182,7 @@ class TestsGeneric:
         if test_lib.is_rhel_atomic_host(host):
             pytest.skip('Not run in atomic images')
 
-        product_version = version.parse(host.system_info.release)
+        system_release = version.parse(host.system_info.release)
 
         release_file = 'redhat-release'
         if host.system_info.distribution == 'fedora':
@@ -190,10 +190,10 @@ class TestsGeneric:
 
         with host.sudo():
             command_to_run = "rpm -q --qf '%{VERSION}' --whatprovides " + release_file
-            package_release_version = version.parse(host.check_output(command_to_run))
+            package_release = version.parse(host.check_output(command_to_run))
 
-        assert product_version == package_release_version, \
-            f'product version ({product_version}) does not match package release version'
+        assert system_release == package_release, \
+            f'Product version ({system_release}) does not match package release version'
 
     @pytest.mark.run_on(['rhel'])
     def test_root_is_locked(self, host):
@@ -828,8 +828,8 @@ class TestsAuthConfig:
         self.__check_pam_d_file_content(host, 'system-auth')
 
     def __check_pam_d_file_content(self, host, file_name):
-        product_major_version = version.parse(host.system_info.release).major
-        local_file = f'data/generic/{file_name}_rhel{product_major_version}'
+        system_release_major_version = version.parse(host.system_info.release).major
+        local_file = f'data/generic/{file_name}_rhel{system_release_major_version}'
         file_to_check = f'/etc/pam.d/{file_name}'
 
         assert test_lib.compare_local_and_remote_file(host, local_file, file_to_check), \
@@ -853,7 +853,7 @@ class TestsKdump:
             arch = host.system_info.arch
 
             # BugZilla 2214235
-            if version.parse(kernel_version) < version.parse("4.18.0") and arch == 'aarch64':
+            if version.parse(kernel_version) < version.parse('4.18.0') and arch == 'aarch64':
                 pytest.skip(f'Skip on arm64 with kernel version {kernel_version}')
 
             print(f' - kexec-tools version: {host.run("rpm -qa | grep kexec-tools").stdout}')

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -3,11 +3,10 @@ import re
 import time
 
 import pytest
-
-from lib import test_lib
-from lib import console_lib
-
 from packaging import version
+
+from lib import console_lib
+from lib import test_lib
 
 
 @pytest.mark.order(1)
@@ -57,9 +56,9 @@ class TestsGeneric:
         """
         Check that crashkernel is enabled in image.
         """
-        product_release_version = float(host.system_info.release)
+        product_release_version = version.parse(host.system_info.release)
 
-        if product_release_version < 9.0:
+        if product_release_version < version.parse('9.0'):
             expected_content = 'crashkernel=auto'
         else:
             with host.sudo():
@@ -136,9 +135,9 @@ class TestsGeneric:
         BugZilla 1938930
         Issue RHELPLAN-60817
         """
-        product_version = float(host.system_info.release)
+        product_version = version.parse(host.system_info.release)
 
-        if product_version < 8.0:
+        if product_version < version.parse('8.0'):
             rpm_to_check = 'redhat-release-server'
         else:
             rpm_to_check = 'redhat-release'
@@ -183,7 +182,7 @@ class TestsGeneric:
         if test_lib.is_rhel_atomic_host(host):
             pytest.skip('Not run in atomic images')
 
-        product_version = float(host.system_info.release)
+        product_version = version.parse(host.system_info.release)
 
         release_file = 'redhat-release'
         if host.system_info.distribution == 'fedora':
@@ -191,7 +190,7 @@ class TestsGeneric:
 
         with host.sudo():
             command_to_run = "rpm -q --qf '%{VERSION}' --whatprovides " + release_file
-            package_release_version = float(host.check_output(command_to_run))
+            package_release_version = version.parse(host.check_output(command_to_run))
 
         assert product_version == package_release_version, \
             f'product version ({product_version}) does not match package release version'
@@ -228,7 +227,7 @@ class TestsGeneric:
 
         with host.sudo():
             if host.file('/sys/firmware/efi').exists:
-                if float(host.system_info.release) < 8.0:
+                if version.parse(host.system_info.release) < version.parse('8.0'):
                     linked_to = '/boot/efi/EFI/redhat/grubenv'
 
             assert host.file(grub2_file).linked_to == linked_to
@@ -326,7 +325,7 @@ class TestsGeneric:
         file_to_check = '/etc/yum/pluginconf.d/langpacks.conf'
 
         with host.sudo():
-            if float(host.system_info.release) < 8.0:
+            if version.parse(host.system_info.release) < version.parse('8.0'):
                 assert test_lib.compare_local_and_remote_file(host, local_file, file_to_check), \
                     f'{file_to_check} has unexpected content'
             else:
@@ -700,7 +699,8 @@ class TestsNetworking:
         }
 
         # EXDSP-813
-        if instance_data['cloud'] == 'azure' and float(host.system_info.release) == 8.5:
+        if instance_data['cloud'] == 'azure' and \
+                version.parse(host.system_info.release) == version.parse('8.5'):
             pytest.skip("There is a known issue affecting RHEL 8.5 on Azure images and won't be fixed (EXDSP-813).")
 
         with host.sudo():
@@ -828,7 +828,7 @@ class TestsAuthConfig:
         self.__check_pam_d_file_content(host, 'system-auth')
 
     def __check_pam_d_file_content(self, host, file_name):
-        product_major_version = int(float(host.system_info.release))
+        product_major_version = version.parse(host.system_info.release).major
         local_file = f'data/generic/{file_name}_rhel{product_major_version}'
         file_to_check = f'/etc/pam.d/{file_name}'
 


### PR DESCRIPTION
Before we were comparing floats, but it turns out that it is not accurate, since in the case of RHEL 8.10, it is semantically greater than e.g. 8.4, however if they are compared as float, 8.4 is greater than 8.10.