### PR TITLE
Improved output of test_no_avc_denials test case for better debugging.

### DIFF
--- a/lib/test_lib.py
+++ b/lib/test_lib.py
@@ -194,7 +194,7 @@ def filter_host_log_file_by_keywords(host,
         return None
 
 
-def print_host_command_output(host, command, use_sudo=True):
+def print_host_command_output(host, command, capture_result=False, use_sudo=True):
     console_lib.print_divider(command)
 
     if use_sudo:
@@ -209,3 +209,6 @@ def print_host_command_output(host, command, use_sudo=True):
         print(f'Stderr:\n{result.stderr}\n')
     else:
         print(result.stdout)
+
+    if capture_result:
+        return result

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -18,9 +18,15 @@ class TestsGeneric:
         """
         if instance_data['cloud'] == 'azure':
             pytest.skip('Skipping on fedora due to old image definitions')
-        with host.sudo():
-            assert 'no matches' in host.check_output('x=$(ausearch -m avc 2>&1 &); echo $x'), \
-                'There should not be any avc denials (selinux)'
+
+        command_to_run = 'x=$(ausearch -m avc 2>&1 &); echo $x'
+        result = test_lib.print_host_command_output(host,
+                                                    command_to_run,
+                                                    capture_result=True)
+
+        no_avc_denials_found = 'no matches' in result.stdout
+
+        assert no_avc_denials_found, 'There should not be any avc denials (selinux)'
 
     @pytest.mark.run_on(['all'])
     def test_bash_history_is_empty(self, host):


### PR DESCRIPTION
Also improved test_lib.print_host_command_output() function to return the command result object so that we don't re-run commands when printing and handling output data at the same time.