### PR TITLE
AzureConfigBuilderV2: gracefully handle dot in release versions

### DIFF
--- a/cloud/terraform/azure_config_builder_v2.py
+++ b/cloud/terraform/azure_config_builder_v2.py
@@ -112,9 +112,10 @@ class AzureConfigBuilderV2(BaseConfigBuilder):
             r"(?P<date>\d{4}\d{2}\d{2})\.\b(?:sp\.)?(?P<build_nr>\d+)\.(?P<arch>\S*)\.\bvhd"
         )
 
+        # thozza NB: the 'version' number may contain dot to separate the major and minor version
         azure_vhd_regex_image_builder = (
             r"https:\/\/(?P<storage_account>.*)\.blob.*\/image-(?P<product_name>.*)-"
-            r"(?P<version>\d+)-(?P<arch>x86_64|aarch64).*.vhd"
+            r"(?P<version>(?:[\d]+\.)?\d+)-(?P<arch>x86_64|aarch64).*.vhd"
         )
 
         matches = re.match(azure_vhd_regex, vhd_uri, re.IGNORECASE)


### PR DESCRIPTION
An osbuild-composer PR#3887 [1] introduces "dot-notation" for distro versions, meaning that a dot will be used to separate major and minor version in distro names. For backward compatibility, distro names without a dot will be still accepted for distros which used to accept it.

The CIV code parsing a VHD name was not expecting the version to contain any dot. This results in failures such as [2].

Modify the regular expression to gracefully handle potential dot in the version string.

[1] https://github.com/osbuild/osbuild-composer/pull/3887
[2] https://gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/-/jobs/5943494707#L3695