### PR TITLE
Use correct detection of modified cfg in test_cloud_cfg()

### DIFF
--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -585,11 +585,12 @@ class TestsCloudInit:
         """
         Verify file /etc/cloud/cloud.cfg is not changed
         """
-        package_to_check = 'cloud-init'
+        cloud_cfg = '/etc/cloud/cloud.cfg'
+        verify_cmd = f'rpm -Vf {cloud_cfg} | grep -e "^S.5.*{cloud_cfg}$"'
 
         with host.sudo():
-            assert host.run_test(f'rpm -V {package_to_check}'), \
-                f'There should not be changes in {package_to_check} package'
+            assert not host.run(verify_cmd).stdout, \
+                f'There should not be changes in {cloud_cfg} package'
 
     @pytest.mark.run_on(['rhel9.0'])
     def test_cloud_cfg_netdev_rhel9(self, host):

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -581,16 +581,17 @@ class TestsCloudInit:
             'wheel should not be configured as default_user group'
 
     @pytest.mark.run_on(['rhel'])
-    def test_cloud_cfg(self, host):
+    def test_cloud_configs(self, host):
         """
-        Verify file /etc/cloud/cloud.cfg is not changed
+        Verify files /etc/cloud/cloud.cfg and
+        /etc/cloud/cloud.cfg.d/* are not changed
         """
         cloud_cfg = '/etc/cloud/cloud.cfg'
-        verify_cmd = f'rpm -Vf {cloud_cfg} | grep -e "^S.5.*{cloud_cfg}$"'
+        verify_cmd = f'rpm -Vf {cloud_cfg} | grep -e "^S.5.*{cloud_cfg}"'
 
         with host.sudo():
             assert not host.run(verify_cmd).stdout, \
-                f'There should not be changes in {cloud_cfg} package'
+                f'There should not be changes in {cloud_cfg} or {cloud_cfg}.d/'
 
     @pytest.mark.run_on(['rhel9.0'])
     def test_cloud_cfg_netdev_rhel9(self, host):


### PR DESCRIPTION
Hi,

It seems, that generic check **test_cloud_cfg()** always **PASS**, because **_rpm -V_** only returns **_0_** or **_1_** which makes **host.run_test()** always succeed.

The proposal is to check modification flags of **/etc/cloud/cloud.cfg** in a more accurate way:

`rpm -Vf /etc/cloud/cloud.cfg | grep -e "^S.5.*/etc/cloud/cloud.cfg$"`