### PR TITLE
Added new param/config to specify custom test suite paths.

### DIFF
--- a/cloud-image-val.py
+++ b/cloud-image-val.py
@@ -18,6 +18,11 @@ parser.add_argument('-o', '--output-file',
 parser.add_argument('-t', '--test-filter',
                     help='Use this option to filter tests execution by test name',
                     default=None)
+parser.add_argument('--test-suites',
+                    help='Use this option to specify which test suites will be use for test run.'
+                         'If no test suite is provided, default test suites will be used (see test_suite/)',
+                    nargs='+',
+                    default=None)
 parser.add_argument('-m', '--include-markers',
                     help='Use this option to specify which tests to run that match a pytest markers expression.\n'
                          'The only marker currently supported is "pub" (see pytest.ini for more details)\n'

--- a/lib/config_lib.py
+++ b/lib/config_lib.py
@@ -1,16 +1,16 @@
-import os.path
+import os
 
 import yaml
 
 
 class CIVConfig:
-    config_path = '/tmp/civ_config.yaml'
+    config_path = 'civ_config.yaml'
     command_line_args = {}
 
     config_file_arg_name = 'config_file'
 
     def __init__(self, args=None):
-        if args.config_file is not None:
+        if args and args.config_file:
             self.config_path = args.config_file
 
         self.command_line_args = args.__dict__
@@ -87,6 +87,7 @@ class CIVConfig:
             'parallel': False,
             'stop_cleanup': None,
             'test_filter': None,
+            'test_suites': None,
         }
 
         return config_defaults

--- a/main/cloud_image_validator.py
+++ b/main/cloud_image_validator.py
@@ -112,7 +112,8 @@ class CloudImageValidator:
                              parallel=self.config['parallel'],
                              debug=self.config['debug'])
 
-        return runner.run_tests(self.config['output_file'],
+        return runner.run_tests(self.config['test_suites'],
+                                self.config['output_file'],
                                 self.config['test_filter'],
                                 self.config['include_markers'])
 

--- a/test/test_cloud_image_validator.py
+++ b/test/test_cloud_image_validator.py
@@ -16,6 +16,7 @@ class TestCloudImageValidator:
                    'debug': True,
                    'stop_cleanup': False,
                    'config_file': '/tmp/test_config_file.yml',
+                   'test_suites': ['test_path_1', 'test_path_2'],
                    }
     test_instances = {
         'instance-1': {'public_dns': 'value_1', 'username': 'value_2'},
@@ -133,8 +134,10 @@ class TestCloudImageValidator:
 
         validator.run_tests_in_all_instances(self.test_instances)
 
-        mock_run_tests.assert_called_once_with(
-            validator.config["output_file"], self.test_config["test_filter"], self.test_config["include_markers"])
+        mock_run_tests.assert_called_once_with(self.test_config["test_suites"],
+                                               validator.config["output_file"],
+                                               self.test_config["test_filter"],
+                                               self.test_config["include_markers"])
 
     def test_destroy_infrastructure(self, mocker, validator):
         mock_destroy_infra = mocker.patch.object(


### PR DESCRIPTION
It is an optional argument/config value. If not used, behavior will remain the same. 

This means that we still hardcode the default test suite paths which belong to test_suite/cloud and test_suite/generic directories.