### PR TITLE
Fixed tags check for AWS deployments.

### DIFF
--- a/cloud/terraform/terraform_configurator.py
+++ b/cloud/terraform/terraform_configurator.py
@@ -54,7 +54,7 @@ class TerraformConfigurator:
         cloud_name = self.resources_dict['provider']
 
         if cloud_name == 'aws':
-            if 'aws-efs' in self.config['tags']:
+            if self.config['tags'] and 'aws-efs' in self.config['tags'].keys():
                 return AWSConfigBuilderEfs(self.resources_dict, self.ssh_key_path, self.config)
             return AWSConfigBuilder(self.resources_dict, self.ssh_key_path, self.config)
         elif cloud_name == 'azure':


### PR DESCRIPTION
It was crashing in the case there were no tagas at all. So it was trying to find values in  NoneType.
We didn't notice this in the CI since we always use tags.