### PR TITLE
Increase waiting time for SSH up to 5 mins

### DIFF
--- a/cloud/opentofu/opentofu_controller.py
+++ b/cloud/opentofu/opentofu_controller.py
@@ -29,7 +29,7 @@ class OpenTofuController:
         self.wait_for_all_instances_ssh_up()
 
     def wait_for_all_instances_ssh_up(self):
-        seconds_to_wait = 180
+        seconds_to_wait = 300
         instances = self.get_instances()
 
         threads = []


### PR DESCRIPTION
to make it more consistent with osbuild-composer's own test suite and to allow for some VMs which seem to be a bit slow to start.