### PR TITLE
Added logic for RHEL AWS Stratosphere images.

### DIFF
--- a/lib/aws_lib.py
+++ b/lib/aws_lib.py
@@ -1,0 +1,12 @@
+import json
+
+
+def get_aws_instance_identity_from_web(host):
+    instance_document_url = 'http://169.254.169.254/latest/dynamic/instance-identity/document'
+    return json.loads(host.check_output(f'curl -s {instance_document_url}'))
+
+
+def is_rhel_aws_stratosphere(host):
+    instance_data = get_aws_instance_identity_from_web(host)
+
+    return instance_data['billingProducts'] is None

--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -4,13 +4,12 @@ import re
 import pytest
 from packaging import version
 
-from lib import test_lib
+from lib import test_lib, aws_lib
 
 
 @pytest.fixture
 def instance_data_aws_web(host):
-    instance_document_url = 'http://169.254.169.254/latest/dynamic/instance-identity/document'
-    return json.loads(host.check_output(f'curl -s {instance_document_url}'))
+    return aws_lib.get_aws_instance_identity_from_web(host)
 
 
 @pytest.fixture
@@ -553,6 +552,7 @@ class TestsAWS:
 
     @pytest.mark.pub
     @pytest.mark.run_on(['rhel'])
+    @pytest.mark.usefixtures('rhel_aws_marketplace_only')
     def test_yum_group_install(self, host):
         if test_lib.is_rhel_atomic_host(host):
             pytest.skip('Not applicable to Atomic host AMIs')

--- a/test_suite/conftest.py
+++ b/test_suite/conftest.py
@@ -11,7 +11,7 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from test_suite.generic import helpers
 
-from lib import test_lib
+from lib import test_lib, aws_lib
 
 
 def __get_host_info(host):
@@ -156,6 +156,13 @@ def rhel_high_availability_only(host):
 def rhel_atomic_only(host):
     if not test_lib.is_rhel_atomic_host(host):
         pytest.skip('Image is not atomic RHEL')
+
+
+@pytest.fixture
+def rhel_aws_marketplace_only(host, instance_data):
+    # Check if the image is AWS Stratosphere. If so, skip the test.
+    if instance_data['cloud'] == 'aws' and aws_lib.is_rhel_aws_stratosphere(host):
+        pytest.skip('Not applicable to RHEL AWS Stratosphere images.')
 
 
 @pytest.fixture(scope='function', autouse=True)

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -35,7 +35,7 @@ class TestsGeneric:
         Check there is no avc denials (selinux).
         """
         if (host.system_info.distribution == 'rhel' and float(host.system_info.release) == 9.4) \
-           or (host.system_info.distribution == 'centos' and host.system_info.release == "9"):
+                or (host.system_info.distribution == 'centos' and host.system_info.release == "9"):
             pytest.skip('RHEL-24346: Skipping on RHEL-9.4 due to a known issue with NetworkManager.')
 
         # CLOUDX-320: This "if" is pending to be removed
@@ -483,6 +483,7 @@ class TestsServices:
 @pytest.mark.pub
 @pytest.mark.run_on(['rhel'])
 @pytest.mark.exclude_on(['<rhel8.3'])
+@pytest.mark.usefixtures('rhel_aws_marketplace_only')
 class TestsSubscriptionManager:
     def test_subscription_manager_auto(self, host, instance_data):
         """
@@ -640,6 +641,7 @@ class TestsCloudInit:
 
 @pytest.mark.pub
 @pytest.mark.order(3)
+@pytest.mark.usefixtures('rhel_aws_marketplace_only')
 class TestsYum:
     # TODO: confirm if this test needs to be deprecated
     @pytest.mark.run_on(['rhel', 'fedora'])
@@ -920,6 +922,7 @@ class TestsRhelEls:
     A set of test cases that should only run if RHEL minor release is the last one and will enter into ELS mode.
     For example, for RHEL-8, the last minor release is RHEL-8.10, and there won't be any further minor releases for major version 8.
     """
+
     def test_rhui_pkg_is_not_e4s(self, host):
         """
         Make sure the RHUI package is not "e4s".


### PR DESCRIPTION
These changes are part of CLOUDX-993, to adapt our tooling to deal with recent changes that have merged all type of AMIs together in the same testing request.