### PR TITLE
add net.ifnames absence on rhel10 test

### DIFF
--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -367,6 +367,7 @@ class TestsAWS:
                         f'{line} must not be specified in AMIs that are not SAP'
 
     @pytest.mark.run_on(['all'])
+    @pytest.mark.jira_skip(["CLOUDX-994"])
     def test_hostkey_permissions(self, host):
         """
         Check that ssh files permission set are correct.

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -254,6 +254,23 @@ class TestsGeneric:
 
             assert host.file(grub2_file).linked_to == linked_to
 
+    @pytest.mark.run_on(['rhel10'])
+    def test_net_ifnames_usage(self, host):
+        """
+        Check that net.ifnames=0 is not used as a kernel boot parameter
+        Jira: CLOUDX-979
+        """
+
+        kernel_boot_param = 'net.ifnames=0'
+        cmdline_file = '/proc/cmdline'
+        grub_default_file = '/etc/default/grub'
+
+        assert not host.file(cmdline_file).contains(kernel_boot_param), \
+            f'There is unexpected {kernel_boot_param} in kernel real-time boot parameters.'
+
+        assert not host.file(grub_default_file).contains(kernel_boot_param), \
+            f'{kernel_boot_param} is found in {grub_default_file}!'
+
     @pytest.mark.run_on(['rhel'])
     def test_tty0_config(self, host):
         """


### PR DESCRIPTION
Closes [CLOUDX-979](https://issues.redhat.com/browse/CLOUDX-979)