### PR TITLE
ignore W504 in flake8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
         run: pytest --cov-report term-missing --cov=cloud/terraform --cov=result/ --cov=main/ --cov=test_suite/ test/
 
       - name: Python linter
-        run: flake8 --ignore=E501
+        run: flake8 --ignore=E501,W504


### PR DESCRIPTION
## Description

The PR #365 is blocked by flake8 complaining about either [W504](https://www.flake8rules.com/rules/W504.html) and [W503](https://www.flake8rules.com/rules/W503.html), a line break after or before binary operator. Those rules contradict each other. Therefore let's exclude  [W504](https://www.flake8rules.com/rules/W504.html) and [W503](https://www.flake8rules.com/rules/W503.html) and agree to use a line break after binary operators. 

## Changes
 - flake8 ignore rules in CI, ignoring W504