### PR TITLE
add bootc installed test

### DIFF
--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -402,6 +402,21 @@ class TestsGeneric:
                 assert not host.file(file_to_check).exists, \
                     f'{file_to_check} should not exist in RHEL-8 and above'
 
+    @pytest.mark.run_on(['>=rhel9.6', 'rhel10'])
+    def test_bootc_installed(self, host):
+        """
+        Verify the system-reinstall-bootc package is installed
+        JIRA: CLOUDX-1267
+        """
+
+        with host.sudo():
+            print('rpm -q output: ')
+            print(host.run('rpm -q system-reinstall-bootc').stdout)
+            print('yum search output: ')
+            print(host.run('yum search system-reinstall-bootc').stdout)
+            assert host.package("system-reinstall-bootc").is_installed, \
+                'System-reinstall-bootc package expected to be installed in RHEL >= 9.6, 10.0'
+
 
 @pytest.mark.order(3)
 class TestsServices:


### PR DESCRIPTION
## Description

Test the installation of the system-reinstall-bootc package on 9.6 and 10.0

Close [CLOUDX-1267](https://issues.redhat.com/browse/CLOUDX-1267)

## Changes
 - adds a new test case checking the system-reinstall-bootc is installed