### PR TITLE
dhcp-client and gdisk retired in rhel10

### DIFF
--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -259,17 +259,9 @@ class TestsAWS:
             'dracut-config-generic', 'grub2-tools',
         ]
 
-        required_pkgs_v7 = [
-            'kernel', 'yum-utils', 'cloud-init', 'dracut-config-generic',
-            'grub2', 'tar', 'rsync', 'chrony'
-        ]
-
         system_release = version.parse(host.system_info.release)
         if system_release >= version.parse('8.5'):
             required_pkgs.append('NetworkManager-cloud-setup')
-
-        if version.parse('8.3') > system_release >= version.parse('8.0'):
-            required_pkgs.append('rng-tools')
 
         # CLOUDX-451
         if system_release.major == 9 and system_release.minor >= 3 or \
@@ -283,9 +275,6 @@ class TestsAWS:
 
         if test_lib.is_rhel_high_availability(host):
             required_pkgs.extend(['fence-agents-all', 'pacemaker', 'pcs'])
-
-        if system_release < version.parse('8.0'):
-            required_pkgs = required_pkgs_v7
 
         missing_pkgs = [pkg for pkg in required_pkgs if not host.package(pkg).is_installed]
 

--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -273,6 +273,12 @@ class TestsAWS:
                 # UEFI boot mode related packages, not applicable to arm64 AMIs
                 required_pkgs.extend(['efibootmgr', 'grub2-efi-x64', 'shim-x64'])
 
+        # RHELMISC-4466 dhcp-client retired in RHEL10
+        # RHELMISC-6651 gdisk retired in RHEL10
+        if system_release.major >= 10:
+            required_pkgs.remove('dhcp-client')
+            required_pkgs.remove('gdisk')
+
         if test_lib.is_rhel_high_availability(host):
             required_pkgs.extend(['fence-agents-all', 'pacemaker', 'pcs'])
 

--- a/test_suite/cloud/test_azure.py
+++ b/test_suite/cloud/test_azure.py
@@ -252,17 +252,18 @@ class TestsAzure:
         Check that the expected packages are installed.
         """
         wanted_pkgs = [
-            'yum-utils', 'redhat-release-eula', 'cloud-init',
+            'yum-utils', 'redhat-release-eula', 'cloud-init', 'insights-client',
             'tar', 'rsync', 'NetworkManager', 'cloud-utils-growpart', 'gdisk',
             'grub2-tools', 'WALinuxAgent', 'firewalld', 'chrony',
             'hypervkvpd', 'hyperv-daemons-license', 'hypervfcopyd', 'hypervvssd', 'hyperv-daemons'
         ]
 
+        # RHELMISC-4466 dhcp-client retired in RHEL10
+        # RHELMISC-6651 gdisk retired in RHEL10
         system_release = version.parse(host.system_info.release)
-        if system_release < version.parse('8.0'):
-            wanted_pkgs.append('dhclient')
-        else:
-            wanted_pkgs.extend(['insights-client', 'dhcp-client'])
+        if system_release.major >= 10:
+            wanted_pkgs.remove('dhcp-client')
+            wanted_pkgs.remove('gdisk')
 
         missing_pkgs = [pkg for pkg in wanted_pkgs if not host.package(pkg).is_installed]
 


### PR DESCRIPTION
## Description

Remove dhcp-client and gdisk from the list of required installed packages in RHEL10
Also remove EOL releases in the corresponding required installed packages test.

RHELMISC-4466 dhcp-client retired in RHEL10
RHELMISC-6651 gdisk retired in RHEL10

Contributes to [CLOUDX-1302](https://issues.redhat.com/browse/CLOUDX-1302)