### PR TITLE
remove net.ifnames=0 check for rhel10

### DIFF
--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -448,12 +448,15 @@ class TestsAWS:
             assert host.file('/sys/module/nvme_core/parameters/io_timeout').contains(expected_value), \
                 f'Actual value in io_timeout is not {expected_value}'
 
-    @pytest.mark.run_on(['rhel'])
+    @pytest.mark.run_on(['<rhel10'])
     def test_cmdline_ifnames(self, host):
         """
         BugZilla 1859926
         ifnames should be specified
         https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena.html
+
+        RHELPLAN-103894 net.ifnames=0 removed in RHEL10
+        There is a separate test checking on it: test_net_ifnames_usage
         """
         with host.sudo():
             assert host.file('/proc/cmdline').contains('net.ifnames=0'), \


### PR DESCRIPTION
This is to fix a test which fails for RHEL10 on AWS as net.ifnames=0 is deprecated there.
In the future it's desired to unite two test on net.ifnames=0 as reported in [CLOUDX-1303](https://issues.redhat.com/browse/CLOUDX-1303)