### PR TITLE
change root lock test for rhel10

### DIFF
--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -223,7 +223,9 @@ class TestsGeneric:
         Check if root account is locked
         """
         with host.sudo():
-            if test_lib.is_rhel_atomic_host(host):
+            if version.parse(host.system_info.release).major >= 10:
+                result = host.run('passwd -S root | grep -q L').rc
+            elif test_lib.is_rhel_atomic_host(host):
                 result = host.run('passwd -S root | grep -q Alternate').rc
             else:
                 result = host.run('passwd -S root | grep -q LK').rc


### PR DESCRIPTION
In RHEL10, passwd lock is noted as "L", not "LK" as in earlier releases. 