### PR TITLE
Fix type mismatch in get_skip_vars

### DIFF
--- a/schutzbot/get_civ_config.py
+++ b/schutzbot/get_civ_config.py
@@ -12,6 +12,7 @@ import sys
 import yaml
 
 from pprint import pprint
+from typing import Dict, List
 
 
 DEFAULT_CIV_CONFIG_PATH = "/tmp/civ_config.yaml"
@@ -165,23 +166,23 @@ def get_modified_methods_str():
     return " or ".join(list(modified_methods))
 
 
-def get_skip_vars():
-    skip_vars = {
+def get_skip_vars() -> Dict[str, str]:
+    skip_vars: Dict[str, str] = {
         "skip_aws": "false",
         "skip_azure": "false",
         "skip_gcp": "false"
     }
 
-    files_changed = get_files_changed()
+    files_changed: List[str] = get_files_changed()
 
     for file in files_changed:
         if "test_suite/generic/.*" in file:
             return skip_vars
 
     return {
-        "skip_aws": "test_suite/cloud/test_aws.py" in files_changed,
-        "skip_azure": "test_suite/cloud/test_azure.py" in files_changed,
-        "skip_gcp": "test_suite/cloud/test_gcp.py" in files_changed,
+        "skip_aws": "false" if "test_suite/cloud/test_aws.py" in files_changed else "true",
+        "skip_azure": "false" if "test_suite/cloud/test_azure.py" in files_changed else "true",
+        "skip_gcp": "false" if "test_suite/cloud/test_gcp.py" in files_changed else "true",
     }
 
 


### PR DESCRIPTION
skip_aws, skip_azure, skip_gcp are expected to be strings not booleans.
-----------

The existing implementation is troublesome as it uses a combination of shell scripts and python code.
There is no type safety in place that ensures types are not mismatched which is reason enough for a refactoring of the existing code.

Example implementation for this code:
```
def get_skip_vars() -> Dict[str, str]:
    files_changed : List[str] = get_files_changed()

    if any("test_suite/generic/" in file for file in files_changed):
        return {cloud: "false" for cloud in ["skip_aws", "skip_azure", "skip_gcp"]}

    return {f"skip_{cloud}": "true" if f"test_suite/cloud/test_{cloud}.py" in files_changed else "false"
            for cloud in ["aws", "azure", "gcp"]}
```