### PR TITLE
return accidenly removed skip on smartcard_auth test

### DIFF
--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -931,7 +931,7 @@ class TestsAuthConfig:
         """
         self.__check_pam_d_file_content(host, 'postlogin')
 
-    @pytest.mark.exclude_on(['>=rhel10.0'])
+    @pytest.mark.exclude_on(['>=rhel10.0', 'rhel8.10'])
     def test_smartcard_auth(self, host):
         """
         Check file /etc/pam.d/smartcard-auth


### PR DESCRIPTION
In [PR#392](https://github.com/osbuild/cloud-image-val/pull/392) in [this line](https://github.com/osbuild/cloud-image-val/pull/392/files#diff-6e493f324d72e518b7e1570ff75ebdad6f8125756bd4e28e6bbc9cb7f413cbabL910), I removed exclude marker pointing to a Jira ticket for smartcard-auth pam file content which was marked for an issue for RHEL8.9 which is EOL. That PR merge happened while a part of our CI was down and we were not aware of it yet, and it resulted in a false positive. Now, when our CI back fully we see it fails on 8.10 GA. Therefore, returning that exclude marker back.