### PR TITLE
fix smartcard-auth test for 8.10

### DIFF
--- a/data/generic/smartcard-auth_rhel8.10
+++ b/data/generic/smartcard-auth_rhel8.10
@@ -1,0 +1,4 @@
+#%PAM-1.0
+# This file is auto-generated.
+# User changes will be destroyed the next time authselect is run.
+auth sufficient pam_sss.so allow_missing_name

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -931,14 +931,19 @@ class TestsAuthConfig:
         """
         self.__check_pam_d_file_content(host, 'postlogin')
 
-    @pytest.mark.exclude_on(['>=rhel10.0', 'rhel8.10'])
+    @pytest.mark.exclude_on(['>=rhel10.0'])
     def test_smartcard_auth(self, host):
         """
         Check file /etc/pam.d/smartcard-auth
         Bugzilla: 1983683
         """
-
-        self.__check_pam_d_file_content(host, 'smartcard-auth')
+        if version.parse(host.system_info.release) == version.parse('8.10'):
+            local_file = 'data/generic/smartcard-auth_rhel8.10'
+            file_to_check = '/etc/pam.d/smartcard-auth'
+            assert test_lib.compare_local_and_remote_file(host, local_file, file_to_check), \
+                f'{file_to_check} has unexpected content'
+        else:
+            self.__check_pam_d_file_content(host, 'smartcard-auth')
 
     @pytest.mark.exclude_on(['>=rhel10.0'])
     def test_system_auth(self, host):


### PR DESCRIPTION
Since the changes in a PAM file were introduced starting from 8.9, and it's EOL we check 8.10 exceptionally only. 
For other releases / minor versions anything stays intact-ed.

Fix #398 

@F-X64 one more please.  =D It was faster than anticipated. 