### PR TITLE
set correct key permissions

### DIFF
--- a/lib/ssh_lib.py
+++ b/lib/ssh_lib.py
@@ -29,6 +29,8 @@ def generate_ssh_key_pair(identity_file):
             encryption_algorithm=serialization.NoEncryption()
         ))
 
+    os.chmod(identity_file, 0o600)
+
     # Generate public key
     public_key = private_key.public_key()
 


### PR DESCRIPTION
[PR371](https://github.com/osbuild/cloud-image-val/pull/371)  changed the tool used to create ssh keys. ssh-keygen sets correct permissions on the private part of a key - 600, meanwhile rsa from cryptography uses the system umask. 
It resulted in wrong permissions used, and consequently the team's keys couldn't be copied on created VMs. 

Fix [CLOUDX-1301](https://issues.redhat.com/browse/CLOUDX-1301)