### PR TITLE
retire hypervfcopyd in RHEL10 aarch64

### DIFF
--- a/test_suite/cloud/test_azure.py
+++ b/test_suite/cloud/test_azure.py
@@ -259,9 +259,13 @@ class TestsAzure:
         ]
 
         # RHELMISC-6651 gdisk retired in RHEL10
+        # CLOUDX-1335 hypervfcopyd retired in RHEL10 aarch64
         system_release = version.parse(host.system_info.release)
         if system_release.major >= 10:
             wanted_pkgs.remove('gdisk')
+
+            if host.system_info.arch == 'aarch64':
+                wanted_pkgs.remove('hypervfcopyd')
 
         missing_pkgs = [pkg for pkg in wanted_pkgs if not host.package(pkg).is_installed]
 


### PR DESCRIPTION
Retire hypervfcopyd in RHEL10 aarch64 on Azure

Close [CLOUDX-1335](https://issues.redhat.com/browse/CLOUDX-1335)