### PR TITLE
change grub param for azure

### DIFF
--- a/test_suite/cloud/test_azure.py
+++ b/test_suite/cloud/test_azure.py
@@ -354,6 +354,12 @@ class TestsAzure:
             'rootdelay=300'
         ]
 
+        if host.system_info.arch == 'aarch64':
+            expected_config = ['console=ttyAMA0']
+
+        if version.parse(host.system_info.release) >= version.parse('9.6'):
+            expected_config.append('nvme_core.io_timeout=240')
+
         with host.sudo():
             for item in expected_config:
                 assert host.file(file_to_check).contains(item), \


### PR DESCRIPTION
aarch64 Azure images should have 'console=ttyAMA0' in grub params instead of others. 
Starting with 9.6 and 10.0, there should be 'nvme_core.io_timeout=240' for all arch. 