### PR TITLE
update runners to match osbuild-composer Schutzfile

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -29,14 +29,14 @@
           {
             "title": "updates",
             "name": "updates",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-x86_64-updates-released-20250501"
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-x86_64-updates-released-20250417"
           }
         ],
         "aarch64": [
           {
             "title": "updates",
             "name": "updates",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-aarch64-updates-released-20250501"
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-aarch64-updates-released-20250417"
           }
         ]
       }


### PR DESCRIPTION
it seems the previous Schutzfile automated PR didn't pick it right, so fixing now. 