### PR TITLE
Workaround for network in CI for RHEL9

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,15 @@ stages:
     - sudo sh get-docker.sh
     - sudo systemctl start docker
     - sudo docker login "${QUAY_IO_CONTAINER_URL}" -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
+    - |
+      if echo "$RUNNER" | grep -iq "rhel-9"; then
+        echo "Applying Podman network_backend fix for RHEL 9"
+        sudo mkdir -p /etc/containers/containers.conf.d
+        echo -e "[network]\nnetwork_backend = \"netavark\"" | sudo tee /etc/containers/containers.conf.d/network_backend.conf
+      else
+        echo "No Podman fix needed for $RUNNER"
+      fi
+
   variables:
     RUNNER: aws/fedora-41-x86_64
     INTERNAL_NETWORK: "true"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,6 @@ stages:
     - sudo sh get-docker.sh
     - sudo systemctl start docker
     - sudo docker login "${QUAY_IO_CONTAINER_URL}" -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
-    - sudo dnf install -y containernetworking-plugins
 
   variables:
     RUNNER: aws/fedora-41-x86_64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,14 +11,7 @@ stages:
     - sudo sh get-docker.sh
     - sudo systemctl start docker
     - sudo docker login "${QUAY_IO_CONTAINER_URL}" -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
-    - |
-      if echo "$RUNNER" | grep -iq "rhel-9"; then
-        echo "Applying Podman network_backend fix for RHEL 9"
-        sudo mkdir -p /etc/containers/containers.conf.d
-        echo -e "[network]\nnetwork_backend = \"netavark\"" | sudo tee /etc/containers/containers.conf.d/network_backend.conf
-      else
-        echo "No Podman fix needed for $RUNNER"
-      fi
+    - sudo dnf install -y containernetworking-plugins
 
   variables:
     RUNNER: aws/fedora-41-x86_64

--- a/ci/.gitlab-ci-cloud-experience.yaml
+++ b/ci/.gitlab-ci-cloud-experience.yaml
@@ -78,5 +78,6 @@ cloudx-packages-testing-aws:
   before_script:
     - echo "Installing CNI plugins for Podman networking"
     - sudo dnf install -y containernetworking-plugins
+    - sudo dnf install -y osbuild-composer-tests
   script:
     - bash ci/aws.sh

--- a/ci/.gitlab-ci-cloud-experience.yaml
+++ b/ci/.gitlab-ci-cloud-experience.yaml
@@ -75,5 +75,8 @@ cloudx-packages-testing-aws:
     RUNNER: $RUN_ON
   rules:
     - if: $CLOUDX_PKG_TESTING == "true" && $PACKAGES_TESTING_AWS == "true"
+  before_script:
+    - echo "Installing CNI plugins for Podman networking"
+    - sudo dnf install -y containernetworking-plugins
   script:
     - bash ci/aws.sh


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add conditional step to configure Podman's network_backend to netavark on RHEL9 CI runners