### PR TITLE
Add region to conf file

### DIFF
--- a/test_suite/package/otel_package/fixtures.py
+++ b/test_suite/package/otel_package/fixtures.py
@@ -67,6 +67,7 @@ exporters:
   awscloudwatchlogs:
     log_group_name: "testing-logs-emf"
     log_stream_name: "testing-integrations-stream-emf"
+    region: "us-east-1"
 
 service:
   pipelines:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Include a "region" field with default value "us-east-1" under awscloudwatchlogs in the test suite configuration