### PR TITLE
unify net.ifnames test

### DIFF
--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -422,20 +422,6 @@ class TestsAWS:
             assert host.file('/sys/module/nvme_core/parameters/io_timeout').contains(expected_value), \
                 f'Actual value in io_timeout is not {expected_value}'
 
-    @pytest.mark.run_on(['<rhel10'])
-    def test_cmdline_ifnames(self, host):
-        """
-        BugZilla 1859926
-        ifnames should be specified
-        https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena.html
-
-        RHELPLAN-103894 net.ifnames=0 removed in RHEL10
-        There is a separate test checking on it: test_net_ifnames_usage
-        """
-        with host.sudo():
-            assert host.file('/proc/cmdline').contains('net.ifnames=0'), \
-                'ifnames expected to be specified'
-
     @pytest.mark.run_on(['rhel'])
     def test_libc6_xen_conf_file_does_not_exist(self, host):
         """


### PR DESCRIPTION
Merge net.ifnames tests. [CLOUDX-1303](https://issues.redhat.com/browse/CLOUDX-1303)

## Summary by Sourcery

Unify the net.ifnames tests by merging AWS-specific checks into the generic test_net_ifnames_usage, applying conditional assertions based on RHEL major version and cloud provider, and eliminate the duplicate AWS test.

Enhancements:
- Consolidate net.ifnames parameter checks into the generic test_net_ifnames_usage
- Add logic to enforce net.ifnames=0 on AWS for RHEL9 and earlier and to drop it for RHEL10 and later
- Update pytest marker to run test_net_ifnames_usage across all RHEL releases

Tests:
- Remove redundant AWS-specific test_cmdline_ifnames from the AWS test suite