### PR TITLE
add RHUI client verification tests for Azure

### DIFF
--- a/test_suite/cloud/test_azure.py
+++ b/test_suite/cloud/test_azure.py
@@ -8,6 +8,87 @@ from lib import console_lib
 from lib import test_lib
 
 
+def get_offer_or_vm_name(instance_data_azure_web):
+    """
+    Helper function to get offer from Azure metadata, with VM name as fallback.
+    Returns a tuple of (source_value, source_type) where source_type is 'Offer' or 'VM name'.
+    """
+    # Get offer from Azure metadata
+    offer = instance_data_azure_web['compute']['storageProfile']['imageReference'].get('offer')
+
+    if offer:
+        return offer, 'Offer'
+
+    # If offer is not found, use VM name as fallback
+    vm_name = instance_data_azure_web['compute'].get('name')
+
+    if vm_name:
+        return vm_name, 'VM name'
+
+    return None, None
+
+
+def get_expected_rhui_rpm_name(host, source_string):
+    """
+    Helper function to determine the expected RHUI client package name
+    based on the system release and Azure VM offer name or VM name.
+    """
+    system_release = version.parse(host.system_info.release)
+
+    # Check for last minor release versions (e.g., RHEL 8.10 or 9.10)
+    is_base_version = system_release.minor == 10
+
+    # Start with the basic name structure
+    expected_rhui_name = f'rhui-azure-rhel{system_release.major}'
+
+    if source_string:
+        # Add source-specific suffixes
+        source_lower = source_string.lower()
+
+        # Dictionary mapping keywords in the source string to the expected RHUI suffix
+        source_suffixes = {
+            'sap-ha': '-sap-ha',
+            'sapapps': '-sapapps',
+            'arm64': '-arm64',
+        }
+
+        # Iterate through the dictionary and check if any key is in the source string.
+        # Add the first matching suffix found.
+        for keyword, suffix in source_suffixes.items():
+            if keyword in source_lower:
+                # Add '-base' suffix if applicable
+                if is_base_version:
+                    expected_rhui_name += '-base'
+                expected_rhui_name += suffix
+                break
+
+    return expected_rhui_name
+
+
+def get_expected_rhui_cert_name(host, source_string):
+    """
+    Determine the expected RHUI certificate name based on RHUI rpm name.
+    Certificate names follow the same pattern as RPM names but with 'content' prefix.
+    """
+    rhui_rpm_name = get_expected_rhui_rpm_name(host, source_string)
+    system_release = version.parse(host.system_info.release)
+
+    # Remove the 'rhui-azure-rhel{version}' part and replace with 'content'
+    rhui_prefix = f'rhui-azure-rhel{system_release.major}'
+
+    # Vanilla RHEL x86 cert name
+    cert_name = 'content.crt'
+
+    if rhui_rpm_name.startswith(rhui_prefix):
+        suffix = rhui_rpm_name[len(rhui_prefix):]  # Get everything after the prefix
+        if suffix:
+            cert_name = f'content{suffix}.crt'
+        elif system_release.minor == 10 or test_lib.is_rhel_cvm:
+            cert_name = 'content-base.crt'
+
+    return cert_name
+
+
 @pytest.fixture
 def instance_data_azure_web(host):  # pylint: disable=bad-indentation
     azure_metadata_url = 'http://169.254.169.254/metadata/instance?api-version=2021-02-01'
@@ -222,44 +303,90 @@ class TestsAzure:
 
     @pytest.mark.pub
     @pytest.mark.run_on(['rhel'])
-    def test_rhui_certificate_date(self, host):
+    def test_rhui_client_rpm_matches_offer(self, host, instance_data_azure_web):
+        """
+        Verify that exactly one RHUI client rpm is installed and that it matches
+        the VM's Offer value or VM name (fallback).
+        """
+        # Get offer from Azure metadata with fallback to VM name
+        source_value, source_type = get_offer_or_vm_name(instance_data_azure_web)
+
+        # Ensure we have either offer or vm_name
+        assert source_value, 'Neither Offer nor VM name is present in Azure metadata. Test cannot proceed.'
+
+        print(f'Azure VM {source_type}: {source_value}')
+
+        # Determine expected RHUI package name using the helper function
+        expected_rhui_name = get_expected_rhui_rpm_name(host, source_value)
+
+        print(f'Expected RHUI client package name: {expected_rhui_name}')
+
+        # Get all installed RHUI client packages
+        rhui_packages_cmd = host.run('rpm -qa | grep "^rhui-azure-rhel"')
+
+        print(f'rhui_packages_cmd.stdout: {rhui_packages_cmd.stdout}')
+        rhui_cmd = host.run('rpm -qa | grep "^rhui"')
+        print(f'rhui_cmd.stdout: {rhui_cmd.stdout}')
+        with host.sudo():
+            system_release = version.parse(host.system_info.release).major
+            rhui_install = host.run(f'yum install -y rhui-azure-rhel{system_release}')
+            print(f'rhui_install.stdout: {rhui_install.stdout}')
+            assert rhui_install.rc == 0, 'Failed to install RHUI client package'
+
+        # Check if the command ran successfully (exit code 0)
+        assert rhui_packages_cmd.rc == 0, 'Failed to get RHUI client packages'
+
+        rhui_packages = rhui_packages_cmd.stdout.strip().split('\n')
+
+        # Filter out empty strings
+        rhui_packages = [pkg for pkg in rhui_packages if pkg]
+
+        print(f'Found RHUI client packages: {rhui_packages}')
+
+        assert len(rhui_packages) == 1, \
+            f'Expected exactly one RHUI client rpm, but found {len(rhui_packages)}: {rhui_packages}'
+
+        installed_package = rhui_packages[0]
+
+        # Check if the installed package name starts with expected name
+        assert installed_package.startswith(expected_rhui_name), \
+            f'RHUI client package "{installed_package}" does not match \
+            expected name "{expected_rhui_name}" for {source_type.lower()} "{source_value}"'
+
+    @pytest.mark.pub
+    @pytest.mark.run_on(['rhel'])
+    def test_rhui_certificate_date(self, host, instance_data_azure_web):
         """
         Verify /etc/pki/rhui/product/content{*}.crt exists.
-        Starting from RHEL 8.8 & 9.2, the certificate file was renamed to content-base.crt.
-        Check end time of the certificate to see if it has expired
+        The certificate name matches the RHUI rpm name pattern.
+        Check end time of the certificate to see if it expires within 10 weeks.
         """
+        # Get offer from Azure metadata with fallback to VM name
+        source_value, source_type = get_offer_or_vm_name(instance_data_azure_web)
+
+        # Ensure we have either offer or vm_name
+        assert source_value, 'Neither Offer nor VM name is present in Azure metadata. Test cannot proceed.'
+
+        print(f'Azure VM {source_type}: {source_value}')
+
+        # Determine expected certificate name using the helper function
+        expected_cert_name = get_expected_rhui_cert_name(host, source_value)
+        cert_file = f'/etc/pki/rhui/product/{expected_cert_name}'
+
+        print(f'Expected RHUI certificate: {cert_file}')
+
         with host.sudo():
-            rhui_package = host.run('rpm -qa | grep rhui').stdout
+            # Check if the expected certificate file exists
+            cert_found = host.file(cert_file).exists
 
-            print(f'Rpm package found: {rhui_package}')
-            test_lib.print_host_command_output(host, f'rpm -ql {rhui_package}')
-            test_lib.print_host_command_output(host, 'yum -v repolist')
+            assert cert_found, f'The RHUI certificate "{cert_file}" was not found.'
 
-            cert_file = ''
-            cert_found = False
+            # Check if certificate is valid for at least 10 weeks from now
+            # 10 weeks = 10 * 7 * 24 * 60 * 60 = 6,048,000 seconds
+            ten_weeks_seconds = 10 * 7 * 24 * 60 * 60
 
-            if test_lib.is_rhel_saphaus(host):
-                cert_file = '/etc/pki/rhui/product/content-sap-ha.crt'
-                cert_found = host.file(cert_file).exists
-            else:
-                possible_cert_files = [
-                    '/etc/pki/rhui/product/content.crt',
-                    '/etc/pki/rhui/product/content-base.crt'
-                ]
-
-                for cert in possible_cert_files:
-                    if host.file(cert).exists:
-                        cert_file = cert
-                        cert_found = True
-                        break
-
-            assert cert_found, 'The RHUI certificate was not found.'
-
-            test_lib.print_host_command_output(host, f'ls -l {cert_file} 2>&1')
-
-            result = host.run(f'openssl x509 -noout -in {cert_file} -enddate -checkend 0')
-
-            print(result.stdout)
+            result = host.run(f'openssl x509 -noout -in {cert_file} -enddate -checkend {ten_weeks_seconds}')
 
             assert result.succeeded, \
-                'The certificate appears to have expired. Check the test case output for more details.'
+                'The certificate will expire within 10 weeks.' \
+                'It should be valid for at least 10 weeks from now.'


### PR DESCRIPTION
These tests ensure:
 - the installed RHUI client rpm matches the VM offer
 - exactly one RHUI client rpm is installed
 - the expected RHUI certificate file exists.
 - the RHUI certificate is valid for at least 10 weeks from the current date

## Summary by Sourcery

Introduce helper functions and tests to validate that the correct Azure RHUI client package is installed for the VM offer and that the corresponding RHUI certificate is present and valid for at least ten weeks.

New Features:
- Add helper functions to compute expected RHUI client RPM and certificate names based on RHEL release and Azure VM offer

Tests:
- Add test to verify exactly one RHUI client RPM is installed and matches the VM's offer
- Enhance RHUI certificate test to use computed certificate name and ensure it exists and remains valid for at least 10 weeks