### PR TITLE
fix skip Cloud logic in CI

### DIFF
--- a/schutzbot/get_civ_config.py
+++ b/schutzbot/get_civ_config.py
@@ -109,7 +109,7 @@ def get_modified_methods():
                     return None
                 elif method[0:4] != 'test':
                     print(f'The method "{method}" is not a test')
-                    return None
+                    continue
                 else:
                     modified_methods.add(method)
 


### PR DESCRIPTION
ok, @F-X64 this tricky one.. Please be extra careful when reviewing =)

The problem is that the [skip Cloud logic](https://github.com/osbuild/cloud-image-val/blob/4c7da3162f55a6d73b2a8ad9cf299f0cbc42cc77/schutzbot/get_civ_config.py#L136C1-L136C20) is currently not working.  It can be observed on the example of this [PR#434](https://github.com/osbuild/cloud-image-val/pull/434). In that PR, only test_azure.py file is changed. With Cloud [skip logic](https://github.com/osbuild/cloud-image-val/blob/4c7da3162f55a6d73b2a8ad9cf299f0cbc42cc77/schutzbot/get_civ_config.py#L201) it's assumed in this case AWS testing Ci should be skipped. However, it runs for both AWS and Azure. It happens, because all SKIP_\<CLOUD\> variables [are set to 'false'](https://gitlab.com/redhat/services/products/image-builder/ci/cloud-image-val-ci/-/jobs/10717037369#L1013) , where it should be 'false' only for SKIP_AZURE. 

To me, the issue seems in changed line, because the current one returns None... as soon as it hits a helper function change in PR#434 and doesn't continue to check changed methods further. That "None" defaults all SKIP_\<Cloud\> variables to "false" [here](https://github.com/osbuild/cloud-image-val/blob/4c7da3162f55a6d73b2a8ad9cf299f0cbc42cc77/schutzbot/get_civ_config.py#L201). 

So, let's see if it fixes the issue after merging.. I see other changes needed, but for debugging and troubleshooting purposes, I'd like to isolate this particular flaw.

## Summary by Sourcery

Bug Fixes:
- Use continue instead of return None for non-test methods in get_modified_methods to avoid aborting the loop prematurely and restore proper SKIP_<CLOUD> variable logic