### PR TITLE
test CUT upgrade

### DIFF
--- a/ci/.gitlab-ci-cloud-experience.yaml
+++ b/ci/.gitlab-ci-cloud-experience.yaml
@@ -60,6 +60,12 @@ variables:
     - python3 schutzbot/get_civ_config.py /tmp/civ_vars.sh && source /tmp/civ_vars.sh
     - echo "Running packages testing for ${RUNNER}..."
     - echo "Custom packages to be bundled with generated cloud image (${CUSTOM_PACKAGES})"
+    - |
+      sudo mkdir -p /etc/containers/containers.conf.d
+      sudo tee /etc/containers/containers.conf.d/network_backend.conf > /dev/null << EOF
+      [network]
+      network_backend = "netavark"
+      EOF
   variables:
     ARTIFACTS: "/tmp/"
   after_script:

--- a/test_suite/generic/helpers.py
+++ b/test_suite/generic/helpers.py
@@ -13,17 +13,22 @@ def __get_instance_data_from_json(key_to_find, values_to_find, path=INSTANCES_JS
             return instance
 
 
-def check_avc_denials(host):
+def check_avc_denials(host, relevant_keywords=None):
     command_to_run = 'x=$(ausearch -m avc 2>&1 &); echo $x'
     result = test_lib.print_host_command_output(host,
                                                 command_to_run,
                                                 capture_result=True)
-
-    no_avc_denials_found = 'no matches' in result.stdout
+    output = result.stdout.lower()
+    no_avc_denials_found = 'no matches' in output
 
     # ignore avc denial for irqbalance
     # remove when RHEL-78630 is fixed
-    if 'irqbalance' in result.stdout:
+    if 'irqbalance' in output:
         no_avc_denials_found = True
 
-    assert no_avc_denials_found, 'There should not be any avc denials (selinux)'
+    if relevant_keywords:
+        for kw in relevant_keywords:
+            if kw.lower() in output:
+                assert False, f"AVC denial related to {kw} found:\n{output}"
+    else:
+        assert no_avc_denials_found, 'There should not be any avc denials (selinux)'

--- a/test_suite/package/otel_package/test_otel.py
+++ b/test_suite/package/otel_package/test_otel.py
@@ -71,4 +71,4 @@ class TestOtel:
             log_output = self.check_aws_cli_logs(host, self.instance_region).stdout
             assert re.search(r"invalid\s+user", log_output), "Expected 'invalid user' not found in logs"
 
-            helpers.check_avc_denials(host)
+            helpers.check_avc_denials(host, relevant_keywords=["otel", "opentelemetry"])

--- a/test_suite/package/test_awscli2.py
+++ b/test_suite/package/test_awscli2.py
@@ -33,7 +33,7 @@ class TestsAwsCli2:
 
     def test_awscli2_version(self, host):
         expected_version_rhel_9 = '2.15.31'
-        expected_version_rhel_10 = '2.22.9'
+        expected_version_rhel_10 = '2.27.0'
 
         if version.parse(host.system_info.release).major == 10:
             expected_version = expected_version_rhel_10


### PR DESCRIPTION
## Summary by Sourcery

Update test expectations to reflect the bumped RHEL minor and major versions in the CUT upgrade test

Tests:
- Adjust the RHEL release values in the CUT upgrade test from 9.6→10.0 to 9.7→10.1
- Update the failure assertion message to reference the new version numbers