### PR TITLE
remove 9.5 runners, add 9.6 and 10.0 ga runners

### DIFF
--- a/ci/.gitlab-ci-image-builder.yaml
+++ b/ci/.gitlab-ci-image-builder.yaml
@@ -4,9 +4,8 @@
 .rhel_runners: &rhel_runners
   RUNNER:
     - aws/rhel-8.10-ga-x86_64
-    - aws/rhel-9.5-ga-x86_64
-    #- aws/rhel-9.6-ga-x86_64
-    #- aws/rhel-10.0-ga-x86_64
+    - aws/rhel-9.6-ga-x86_64
+    - aws/rhel-10.0-ga-x86_64
     - aws/centos-stream-9-x86_64
     - aws/centos-stream-10-x86_64
   NIGHTLY: [ "false" ]
@@ -14,9 +13,8 @@
 .rhel_runners_aarch64: &rhel_runners_aarch64
   RUNNER:
     - aws/rhel-8.10-ga-aarch64
-    - aws/rhel-9.5-ga-aarch64
-    #- aws/rhel-9.6-ga-aarch64
-    #- aws/rhel-10.0-ga-aarch64
+    - aws/rhel-9.6-ga-aarch64
+    - aws/rhel-10.0-ga-aarch64
     - aws/centos-stream-9-aarch64
     - aws/centos-stream-10-aarch64
   INTERNAL_NETWORK: [ "true" ]


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Replace RHEL 9.5 GA runners with RHEL 9.6 and 10.0 GA runners for both x86_64 and aarch64 in the CI image builder configuration