### PR TITLE
data/azure/grub9.6+: update expected grub config

### DIFF
--- a/data/azure/grub_rhel9.6+
+++ b/data/azure/grub_rhel9.6+
@@ -6,5 +6,7 @@ GRUB_DISABLE_SUBMENU=true
 GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
 GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
 GRUB_TERMINAL="serial"
+GRUB_TERMINAL_INPUT="serial"
+GRUB_TERMINAL_OUTPUT="serial"
 GRUB_TIMEOUT_STYLE=countdown
 GRUB_DEFAULT=saved


### PR DESCRIPTION
Update the expected grub config to match the latest changes.

https://github.com/osbuild/images/pull/1814

RHEL 9: RHEL-95423
RHEL 10: RHEL-95418

## Summary by Sourcery

Tests:
- Refresh the data/azure/grub_rhel9.6+ test fixture to align with updated grub config lines for RHEL 9 and 10