### PR TITLE
Update version checks for nvme_core.io_timeout on Azure

### DIFF
--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -104,9 +104,11 @@ class TestsGeneric:
         if host.system_info.arch == 'x86_64' and instance_data['cloud'] == 'azure':
             expected_config.extend(['earlyprintk=ttyS0', 'rootdelay=300'])
 
-        # Add RHEL 9.6+ specific parameter
-        if version.parse(host.system_info.release) >= version.parse('9.6') and \
-                instance_data['cloud'] == 'azure':
+        # nvme_core.io_timeout was only set in 4 versions of RHEL
+        release = version.parse(host.system_info.release)
+        if instance_data['cloud'] == 'azure' and \
+                (version.parse('9.6') <= release < version.parse('9.8')
+                 or version.parse('10.0') <= release < version.parse('10.2')):
             expected_config.append('nvme_core.io_timeout=240')
 
         # CVM specific parameters


### PR DESCRIPTION
The command line argument was dropped on 9.8+ and 10.2+. See https://github.com/osbuild/images/pull/2127 as well as RHEL-126678 and RHEL-127204.