### PR TITLE
Fix AWS test failures - Update tests for current image state

### DIFF
--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -87,24 +87,30 @@ class TestsAWS:
     @pytest.mark.run_on(['rhel'])
     def test_iommu_strict_mode(self, host):
         """
-        Use "iommu.strict=0" in ARM AMIs to get better performance.
-        BugZilla 1836058
-        CLOUDX-1517, RHEL-115405
+        Checks the status of the "iommu.strict=0" kernel option on RHEL AMIs.
+        The option should be:
+        - Not present on x86_64 images (all versions)
+        - Present on RHEL 8 ARM images (BugZilla 1836058)
+        - Not present on RHEL 9+ ARM images (CLOUDX-1517, RHEL-115405)
         """
         option = 'iommu.strict=0'
         release_major = version.parse(host.system_info.release).major
+        arch = host.system_info.arch
 
         with host.sudo():
             iommu_option_present = host.file('/proc/cmdline').contains(option)
 
-            if host.system_info.arch == 'x86_64':
+            if arch == 'x86_64':
                 assert not iommu_option_present, f'{option} must not be present in x86_64 AMIs'
-            elif release_major >= 9:
-                assert not iommu_option_present, \
-                    f'{option} must not be present in RHEL {release_major} ARM AMIs (CLOUDX-1517)'
+            elif arch == 'aarch64':
+                if release_major >= 9:
+                    assert not iommu_option_present, \
+                        f'{option} must not be present in RHEL {release_major} ARM AMIs (CLOUDX-1517)'
+                else:
+                    assert iommu_option_present, \
+                        f'{option} must be present in RHEL {release_major} ARM AMIs (BugZilla 1836058)'
             else:
-                assert iommu_option_present, \
-                    f'{option} must be present in RHEL {release_major} ARM AMIs'
+                pytest.fail(f'Unexpected architecture: {arch}. This test only supports x86_64 and aarch64.')
 
     @pytest.mark.run_on(['rhel'])
     def test_unwanted_packages_are_not_present(self, host):

--- a/test_suite/cloud/test_aws.py
+++ b/test_suite/cloud/test_aws.py
@@ -89,16 +89,22 @@ class TestsAWS:
         """
         Use "iommu.strict=0" in ARM AMIs to get better performance.
         BugZilla 1836058
+        CLOUDX-1517, RHEL-115405
         """
         option = 'iommu.strict=0'
+        release_major = version.parse(host.system_info.release).major
 
         with host.sudo():
             iommu_option_present = host.file('/proc/cmdline').contains(option)
 
             if host.system_info.arch == 'x86_64':
                 assert not iommu_option_present, f'{option} must not be present in x86_64 AMIs'
+            elif release_major >= 9:
+                assert not iommu_option_present, \
+                    f'{option} must not be present in RHEL {release_major} ARM AMIs (CLOUDX-1517)'
             else:
-                assert iommu_option_present, f'{option} must be present in ARM AMIs'
+                assert iommu_option_present, \
+                    f'{option} must be present in RHEL {release_major} ARM AMIs'
 
     @pytest.mark.run_on(['rhel'])
     def test_unwanted_packages_are_not_present(self, host):

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -809,9 +809,8 @@ class TestsGeneric:
         def cleanup_dev_tools():
             with host.sudo():
                 print('Cleaning up Development tools packages...')
-                cleanup_result = host.run('yum -y groupremove "Development tools"')
-                if cleanup_result.failed:
-                    print(f'Warning: Failed to clean up Development tools: {cleanup_result.stderr}')
+                assert host.run_test('dnf -y history undo last'), \
+                    'Failed to cleanup Development tools packages'
 
         request.addfinalizer(cleanup_dev_tools)
 
@@ -822,7 +821,7 @@ class TestsGeneric:
                 f'RPM database is corrupted or inaccessible. Error: {rpm_check.stderr}. ' \
                 'This is a system-level issue that must be resolved.'
 
-            dev_tools_install_command = 'yum -y groupinstall "Development tools"'
+            dev_tools_install_command = 'dnf -y groupinstall "Development tools"'
             result = host.run(dev_tools_install_command)
 
             if result.failed:
@@ -1069,9 +1068,13 @@ class TestsSubscriptionManager:
                 subscription_status = host.run(
                     'subscription-manager status').stdout
 
-                if 'Red Hat Enterprise Linux' in subscription_status or \
-                        'Simple Content Access' in subscription_status or \
-                        'Overall Status: Registered' in subscription_status:
+                is_registered = (
+                    'Red Hat Enterprise Linux' in subscription_status or
+                    'Simple Content Access' in subscription_status or
+                    'Overall Status: Registered' in subscription_status
+                )
+
+                if is_registered:
                     print('Subscription auto-registration completed successfully')
 
                     if not host.run_test('insights-client --register'):
@@ -1081,6 +1084,8 @@ class TestsSubscriptionManager:
 
                 end_time = time.time()
                 if end_time - start_time > timeout:
+                    assert is_registered, \
+                        f'Unexpected subscription-manager status output: {subscription_status!r}'
                     assert host.run_test('insights-client --register'), \
                         'insights-client could not register successfully'
                     pytest.fail(

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -784,7 +784,7 @@ class TestsGeneric:
     @pytest.mark.pub
     @pytest.mark.run_on(['rhel'])
     @pytest.mark.usefixtures('rhel_aws_marketplace_only')
-    def test_yum_group_install(self, host, instance_data):
+    def test_yum_group_install(self, host, instance_data, request):
         """
         Test that the "Development tools" package group can be successfully installed.
 
@@ -805,6 +805,15 @@ class TestsGeneric:
         # Image-builder builds don't include RHUI (only brew/pungi builds do)
         if instance_data['cloud'] == 'oci':
             pytest.skip('OCI image-builder builds do not include RHUI configuration')
+
+        def cleanup_dev_tools():
+            with host.sudo():
+                print('Cleaning up Development tools packages...')
+                cleanup_result = host.run('yum -y groupremove "Development tools"')
+                if cleanup_result.failed:
+                    print(f'Warning: Failed to clean up Development tools: {cleanup_result.stderr}')
+
+        request.addfinalizer(cleanup_dev_tools)
 
         with host.sudo():
             # Assert RPM database health before attempting installation
@@ -1061,7 +1070,8 @@ class TestsSubscriptionManager:
                     'subscription-manager status').stdout
 
                 if 'Red Hat Enterprise Linux' in subscription_status or \
-                        'Simple Content Access' in subscription_status:
+                        'Simple Content Access' in subscription_status or \
+                        'Overall Status: Registered' in subscription_status:
                     print('Subscription auto-registration completed successfully')
 
                     if not host.run_test('insights-client --register'):
@@ -1385,7 +1395,7 @@ class TestsAuthConfig:
             expected_config_files = [
                 'authselect.conf', 'custom', 'dconf-db', 'dconf-locks',
                 'fingerprint-auth', 'nsswitch.conf', 'password-auth',
-                'postlogin', 'smartcard-auth', 'switchable-auth', 'system-auth',
+                'postlogin', 'smartcard-auth', 'system-auth',
                 'user-nsswitch.conf'
             ]
         else:

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -1069,9 +1069,9 @@ class TestsSubscriptionManager:
                     'subscription-manager status').stdout
 
                 is_registered = (
-                    'Red Hat Enterprise Linux' in subscription_status or
-                    'Simple Content Access' in subscription_status or
-                    'Overall Status: Registered' in subscription_status
+                    'Red Hat Enterprise Linux' in subscription_status
+                    or 'Simple Content Access' in subscription_status
+                    or 'Overall Status: Registered' in subscription_status
                 )
 
                 if is_registered:


### PR DESCRIPTION
Fixed four test failures that were caused by automation drift:

1. test_authselect_conf_files (AWS):
   - Removed switchable-auth from AWS expected files
   - switchable-auth introduced in authselect 1.7.0+ (Jan 2025)
   - Not present in current RHEL 9.8 AWS images
   - Tested on ami-0bb64587efd91f63e (RHEL 9.8 us-east-2): PASSED

2. test_iommu_strict_mode (AWS ARM):
   - Added version-specific logic for RHEL 9/10 ARM
   - RHEL 9/10: CONFIG_IOMMU_DEFAULT_DMA_STRICT not set, parameter not required
   - RHEL 8: CONFIG_IOMMU_DEFAULT_DMA_STRICT='y', parameter still required
   - Based on CLOUDX-1517 and RHEL-115405

3. test_subscription_manager_auto:
   - Added check for "Overall Status: Registered" status text
   - RHEL 10+ auto-registration v2 changed subscription-manager status output
   - No longer shows "Red Hat Enterprise Linux" or "Simple Content Access"
   - Now shows "Overall Status: Registered" instead
   - Tested on ami-00487d5140419958a (RHEL 10 eu-west-1): PASSED

4. test_yum_group_install cleanup:
   - Added pytest finalizer to remove "Development tools" packages after test
   - Prevents test pollution affecting test_unwanted_packages_are_not_present
   - alsa-lib is NOT in base images but gets installed as dependency
   - Verified: fresh instance has no alsa-lib, but appears after groupinstall
   - Tested: both tests now pass in sequence with cleanup