### PR TITLE
Fix OCI tags property name to use freeform_tags

### DIFF
--- a/cloud/opentofu/oci_config_builder.py
+++ b/cloud/opentofu/oci_config_builder.py
@@ -4,6 +4,7 @@ from cloud.opentofu.base_config_builder import BaseConfigBuilder
 class OCIConfigBuilder(BaseConfigBuilder):
     cloud_name = 'oci'
     cloud_provider_definition = {'oci': {'source': 'oracle/oci', 'version': '~> 8.16'}}
+    resource_tags_key = 'freeform_tags'
 
     def build_providers(self):
         all_regions = self.__get_all_regions_from_resources_file()


### PR DESCRIPTION
The OCI Terraform provider requires 'freeform_tags' instead of 'tags' for resource tagging. Override resource_tags_key in OCIConfigBuilder to match the provider's expected property name.