### PR TITLE
fix(oci): update sshd, driver and /boot tests

### DIFF
--- a/test_suite/cloud/test_oci.py
+++ b/test_suite/cloud/test_oci.py
@@ -117,7 +117,7 @@ class TestsOCI:
         """
         sshd_config = '/etc/ssh/sshd_config'
         with host.sudo():
-            assert not host.file(sshd_config).contains('^PasswordAuthentication yes'), \
+            assert not host.file(sshd_config).contains(r'^\s*PasswordAuthentication\s+yes\b'), \
                 'PasswordAuthentication must not be enabled in OCI images'
             assert host.service('sshd').is_running, \
                 'sshd must be running'

--- a/test_suite/cloud/test_oci.py
+++ b/test_suite/cloud/test_oci.py
@@ -80,8 +80,7 @@ class TestsOCI:
         """
         with host.sudo():
             nic_driver = host.check_output(
-                "find /sys/class/net -maxdepth 2 -name 'uevent' "
-                "| xargs grep -h DRIVER 2>/dev/null | head -1"
+                "grep -h DRIVER /sys/class/net/*/device/uevent"
             )
 
         assert 'virtio' in nic_driver, \
@@ -118,7 +117,7 @@ class TestsOCI:
         """
         sshd_config = '/etc/ssh/sshd_config'
         with host.sudo():
-            assert not host.file(sshd_config).contains('PasswordAuthentication yes'), \
+            assert not host.file(sshd_config).contains('^PasswordAuthentication yes'), \
                 'PasswordAuthentication must not be enabled in OCI images'
             assert host.service('sshd').is_running, \
                 'sshd must be running'

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -325,6 +325,7 @@ class TestsGeneric:
             * 8.y and aarch64
             * 9.y
             * 10.y and Azure and LVM
+            * 10.y and OCI and LVM
             * Fedora
         In all other cases the /boot mount doesn't exist on a system.
         If /boot exists it should be at least 960Mib (lower threshold of 1024MiB)

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -335,13 +335,14 @@ class TestsGeneric:
         release_major = version.parse(host.system_info.release).major
         is_aarch64 = host.system_info.arch == 'aarch64'
         is_azure = instance_data['cloud'] == 'azure'
+        is_oci = instance_data['cloud'] == 'oci'
         lvm_check = host.run("lsblk -f | grep LVM").rc == 0
         is_fedora = host.system_info.distribution == 'fedora'
 
         if (
            (release_major == 8 and is_aarch64)
            or (release_major == 9)
-           or (release_major >= 10 and is_azure and lvm_check)
+           or (release_major >= 10 and (is_azure or is_oci) and lvm_check)
            or is_fedora
            ):
             assert host.mount_point("/boot").exists, "/boot mount is missing"


### PR DESCRIPTION
Fix failing tests for OCI:-

- update sshd to check for uncommented `PsswordAuthentication yes` by updating regex
- update network driver to check the correct uevent file
- add oci as a case for /boot drive as it's lvm only