### PR TITLE
Expect /boot mount on OCI instances

### DIFF
--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -332,6 +332,7 @@ class TestsGeneric:
         release_major = version.parse(host.system_info.release).major
         is_aarch64 = host.system_info.arch == 'aarch64'
         is_azure = instance_data['cloud'] == 'azure'
+        is_oci = instance_data['cloud'] == 'oci'
         lvm_check = host.run("lsblk -f | grep LVM").rc == 0
         is_fedora = host.system_info.distribution == 'fedora'
 
@@ -340,6 +341,7 @@ class TestsGeneric:
            or (release_major == 9)
            or (release_major >= 10 and is_azure and lvm_check)
            or is_fedora
+           or is_oci
            ):
             assert host.mount_point("/boot").exists, "/boot mount is missing"
 


### PR DESCRIPTION
OCI images always have a separate /boot partition, so test_boot_mount_presence should not assert its absence.