### PR TITLE
fix: CIV automation fixes for RHEL 9.8 test failures

### DIFF
--- a/lib/test_lib.py
+++ b/lib/test_lib.py
@@ -17,8 +17,11 @@ def is_rhel_cvm(host):
 
 
 def is_rhel_saphaus(host):
-    # RHEL for SAP HA and US with sap-solutions and sap-netweaver repositories
-    return __test_keyword_in_repositories(host, 'sap-solutions')
+    # RHEL for SAP with sap-solutions and sap-netweaver repositories.
+    # Uses RPM-based detection (like is_rhel_high_availability) instead of
+    # yum repolist, which fails on 3p/stratosphere images without RHUI access.
+    rhui_pkg = str(host.run('rpm -qa | grep rhui').stdout)
+    return re.search(r'rhui.*sap', rhui_pkg)
 
 
 def is_rhel_high_availability(host):

--- a/test_suite/cloud/test_azure.py
+++ b/test_suite/cloud/test_azure.py
@@ -48,6 +48,7 @@ def get_expected_rhui_rpm_name(host, source_string):
         # Dictionary mapping keywords in the source string to the expected RHUI suffix
         source_suffixes = {
             'sap-ha': '-sap-ha',
+            'sap-apps': '-sapapps',
             'sapapps': '-sapapps',
             'arm64': '-arm64',
         }

--- a/test_suite/generic/helpers.py
+++ b/test_suite/generic/helpers.py
@@ -52,7 +52,8 @@ def check_avc_denials(host, relevant_keywords=None):
 
         filtered = [
             line for line in output_lines
-            if "permissive=1" not in line  # skip permissive-mode AVCs
+            if line.strip()
+            and "permissive=1" not in line  # skip permissive-mode AVCs
             and not any(ignored in line for ignored in ignored_keywords)
         ]
 

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -808,12 +808,19 @@ class TestsGeneric:
         if instance_data['cloud'] == 'oci':
             pytest.skip('OCI image-builder builds do not include RHUI configuration')
 
+        with host.sudo():
+            pkgs_before = set(host.check_output('rpm -qa --qf "%{NAME}\\n"').splitlines())
+
         def cleanup_dev_tools():
             with host.sudo():
                 print('Cleaning up Development tools packages...')
                 assert host.run_test('dnf -y history undo last'), \
                     'Failed to cleanup Development tools packages'
-                host.run('dnf -y autoremove')
+                pkgs_after = set(host.check_output('rpm -qa --qf "%{NAME}\\n"').splitlines())
+                leftover = pkgs_after - pkgs_before
+                if leftover:
+                    print(f'Removing leftover packages: {leftover}')
+                    host.run(f'dnf -y remove {" ".join(leftover)}')
 
         request.addfinalizer(cleanup_dev_tools)
 

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -813,6 +813,7 @@ class TestsGeneric:
                 print('Cleaning up Development tools packages...')
                 assert host.run_test('dnf -y history undo last'), \
                     'Failed to cleanup Development tools packages'
+                host.run('dnf -y autoremove')
 
         request.addfinalizer(cleanup_dev_tools)
 


### PR DESCRIPTION
- Switch is_rhel_saphaus() to RPM-based detection matching is_rhel_high_availability() pattern; yum repolist fails on 3p/stratosphere images without RHUI access
- Add 'sap-apps' key to Azure RHUI source_suffixes dict so hyphenated offer names (RHEL-SAP-Apps) resolve correctly
- Filter empty lines in check_avc_denials() to prevent false assertion failures from blank audit log output
- Add dnf autoremove after history undo in test_yum_group_install cleanup to remove orphaned transitive deps like alsa-lib