### PR TITLE
fix: skip auto-registration test for EUSC region

### DIFF
--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -1046,6 +1046,7 @@ class TestsSubscriptionManager:
                 'ap-southeast-4',
                 'eu-south-2',
                 'eu-central-2',
+                'eusc-de-east-1',
                 'us-gov-east-1',
                 'us-gov-west-1',
                 'cn-northwest-1',


### PR DESCRIPTION
EUSC (eusc-de-east-1) is a separate AWS partition like China and GovCloud, which are already skipped. RHUI content delivery works there but the auto-registration backend is not deployed, causing test_subscription_manager_auto to time out.