### PR TITLE
Add JSON Schema for CIV instance metadata contract (CIV-005)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ py==1.11.0
 paramiko==3.4.1
 requests==2.32.3
 packaging==24.1
+jsonschema==4.23.0

--- a/schemas/civ-instances.schema.json
+++ b/schemas/civ-instances.schema.json
@@ -1,0 +1,69 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "CIV Instance Metadata Contract",
+    "description": "Defines the integration contract between CIV provisioner and downstream test suites. The top-level object is a map of instance identifiers (e.g. OpenTofu resource addresses) to instance metadata objects.",
+    "type": "object",
+    "additionalProperties": {
+        "$ref": "#/$defs/instance"
+    },
+    "$defs": {
+        "instance": {
+            "type": "object",
+            "description": "Metadata for a single provisioned cloud instance.",
+            "required": [
+                "name",
+                "address",
+                "username",
+                "cloud",
+                "image"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Human-readable instance name, typically derived from the OpenTofu resource name."
+                },
+                "address": {
+                    "type": "string",
+                    "description": "Network address used for SSH connections. Resolved from public_dns, public_ip, or private_ip in order of preference."
+                },
+                "username": {
+                    "type": "string",
+                    "description": "SSH login username for the instance (e.g. 'ec2-user', 'cloud-user')."
+                },
+                "cloud": {
+                    "type": "string",
+                    "description": "Cloud provider identifier.",
+                    "enum": ["aws", "azure", "gcloud", "oci"]
+                },
+                "image": {
+                    "description": "Cloud image reference used to launch the instance. String on most clouds; may be an object on Azure (source_image_reference)."
+                },
+                "region": {
+                    "type": "string",
+                    "description": "Cloud region where the instance is running (e.g. 'us-east-1')."
+                },
+                "distro": {
+                    "type": "string",
+                    "description": "Linux distribution identifier (e.g. 'rhel', 'fedora')."
+                },
+                "version": {
+                    "type": "string",
+                    "description": "Distribution version (e.g. '9.3')."
+                },
+                "arch": {
+                    "type": "string",
+                    "description": "CPU architecture (e.g. 'x86_64', 'aarch64')."
+                },
+                "image_id": {
+                    "type": "string",
+                    "description": "Cloud-specific image identifier (e.g. AMI ID, image URN)."
+                },
+                "instance_type": {
+                    "type": "string",
+                    "description": "Cloud-specific instance/VM size (e.g. 't3.medium', 'Standard_D2s_v3')."
+                }
+            },
+            "additionalProperties": true
+        }
+    }
+}

--- a/schemas/civ-instances.schema.json
+++ b/schemas/civ-instances.schema.json
@@ -52,7 +52,8 @@
                 },
                 "arch": {
                     "type": "string",
-                    "description": "CPU architecture (e.g. 'x86_64', 'aarch64')."
+                    "description": "CPU architecture.",
+                    "enum": ["x86_64", "aarch64"]
                 },
                 "image_id": {
                     "type": "string",

--- a/test/test_civ_instances_schema.py
+++ b/test/test_civ_instances_schema.py
@@ -1,0 +1,179 @@
+import json
+import os
+import subprocess
+
+import pytest
+
+
+SCHEMA_PATH = os.path.join(os.path.dirname(__file__), '..', 'schemas', 'civ-instances.schema.json')
+
+
+@pytest.fixture
+def schema():
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+def validate(document, schema):
+    """Validate a document against the schema using python -m jsonschema if available, else basic checks."""
+    doc_json = json.dumps(document)
+    schema_json = json.dumps(schema)
+
+    script = (
+        "import json, sys; "
+        "doc = json.loads(sys.argv[1]); "
+        "schema = json.loads(sys.argv[2]); "
+        "from jsonschema import validate, ValidationError; "
+        "validate(doc, schema)"
+    )
+    result = subprocess.run(
+        ['python3', '-c', script, doc_json, schema_json],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise ValueError(result.stderr)
+
+
+def validate_expect_failure(document, schema, match):
+    """Assert that validation fails with an error matching the given string."""
+    with pytest.raises(ValueError, match=match):
+        validate(document, schema)
+
+
+class TestCivInstancesSchema:
+
+    valid_minimal_document = {
+        "aws_instance.civ-rhel-95-12345": {
+            "name": "civ-rhel-95-12345",
+            "address": "ec2-54-123-45-67.us-east-1.compute.amazonaws.com",
+            "username": "ec2-user",
+            "cloud": "aws",
+            "image": "RHEL-9.5-x86_64"
+        }
+    }
+
+    valid_full_document = {
+        "aws_instance.civ-rhel-93-us-east-1": {
+            "name": "rhel-9.3-aws-us-east-1",
+            "address": "54.123.45.67",
+            "username": "ec2-user",
+            "cloud": "aws",
+            "region": "us-east-1",
+            "distro": "rhel",
+            "version": "9.3",
+            "arch": "x86_64",
+            "image_id": "ami-0123456789",
+            "instance_type": "t3.medium",
+            "image": "RHEL-9.3-x86_64",
+            "instance_id": "i-0abc123def456",
+            "public_ip": "54.123.45.67",
+            "public_dns": "ec2-54-123-45-67.us-east-1.compute.amazonaws.com",
+            "private_ip": "10.0.1.5",
+            "availability_zone": "us-east-1a",
+            "ami": "ami-0123456789"
+        }
+    }
+
+    valid_multi_instance_document = {
+        "aws_instance.civ-rhel-95-11111": {
+            "name": "civ-rhel-95-11111",
+            "address": "54.1.2.3",
+            "username": "ec2-user",
+            "cloud": "aws",
+            "image": "RHEL-9.5-x86_64"
+        },
+        "azurerm_linux_virtual_machine.civ-rhel-95-22222": {
+            "name": "civ-rhel-95-22222",
+            "address": "20.1.2.3",
+            "username": "cloud-user",
+            "cloud": "azure",
+            "image": {
+                "publisher": "RedHat",
+                "offer": "RHEL",
+                "sku": "95-gen2",
+                "version": "latest"
+            }
+        }
+    }
+
+    def test_schema_is_valid_json(self, schema):
+        assert schema.get('$schema') is not None
+        assert schema.get('type') == 'object'
+        assert '$defs' in schema
+        assert 'instance' in schema['$defs']
+
+    def test_schema_required_fields(self, schema):
+        instance_def = schema['$defs']['instance']
+        assert set(instance_def['required']) == {'name', 'address', 'username', 'cloud', 'image'}
+
+    def test_schema_optional_fields(self, schema):
+        instance_props = schema['$defs']['instance']['properties']
+        for field in ('region', 'distro', 'version', 'arch', 'image_id', 'instance_type'):
+            assert field in instance_props, f"Optional field '{field}' missing from schema"
+
+    def test_schema_field_descriptions(self, schema):
+        instance_props = schema['$defs']['instance']['properties']
+        for field_name, field_def in instance_props.items():
+            assert 'description' in field_def, f"Field '{field_name}' missing description"
+
+    def test_valid_minimal_document(self, schema):
+        validate(self.valid_minimal_document, schema)
+
+    def test_valid_full_document(self, schema):
+        validate(self.valid_full_document, schema)
+
+    def test_valid_multi_instance(self, schema):
+        validate(self.valid_multi_instance_document, schema)
+
+    def test_valid_empty_document(self, schema):
+        validate({}, schema)
+
+    def test_valid_azure_image_as_object(self, schema):
+        doc = {
+            "azurerm_linux_virtual_machine.civ-vm-1": {
+                "name": "civ-vm-1",
+                "address": "20.1.2.3",
+                "username": "cloud-user",
+                "cloud": "azure",
+                "image": {"publisher": "RedHat", "offer": "RHEL", "sku": "9", "version": "latest"}
+            }
+        }
+        validate(doc, schema)
+
+    def test_invalid_missing_required_field(self, schema):
+        doc = {
+            "instance-1": {
+                "address": "54.123.45.67",
+                "username": "ec2-user",
+                "cloud": "aws",
+                "image": "RHEL-9.5"
+            }
+        }
+        validate_expect_failure(doc, schema, "required property")
+
+    def test_invalid_cloud_value(self, schema):
+        doc = {
+            "instance-1": {
+                "name": "test",
+                "address": "1.2.3.4",
+                "username": "ec2-user",
+                "cloud": "digitalocean",
+                "image": "RHEL-9.5"
+            }
+        }
+        validate_expect_failure(doc, schema, "is not one of")
+
+    def test_invalid_name_type(self, schema):
+        doc = {
+            "instance-1": {
+                "name": 123,
+                "address": "1.2.3.4",
+                "username": "ec2-user",
+                "cloud": "aws",
+                "image": "RHEL-9.5"
+            }
+        }
+        validate_expect_failure(doc, schema, "is not of type")
+
+    def test_invalid_top_level_not_object(self, schema):
+        validate_expect_failure(["not", "an", "object"], schema, "is not of type")

--- a/test/test_civ_instances_schema.py
+++ b/test/test_civ_instances_schema.py
@@ -1,7 +1,7 @@
 import json
 import os
-import subprocess
 
+import jsonschema
 import pytest
 
 
@@ -12,32 +12,6 @@ SCHEMA_PATH = os.path.join(os.path.dirname(__file__), '..', 'schemas', 'civ-inst
 def schema():
     with open(SCHEMA_PATH) as f:
         return json.load(f)
-
-
-def validate(document, schema):
-    """Validate a document against the schema using python -m jsonschema if available, else basic checks."""
-    doc_json = json.dumps(document)
-    schema_json = json.dumps(schema)
-
-    script = (
-        "import json, sys; "
-        "doc = json.loads(sys.argv[1]); "
-        "schema = json.loads(sys.argv[2]); "
-        "from jsonschema import validate, ValidationError; "
-        "validate(doc, schema)"
-    )
-    result = subprocess.run(
-        ['python3', '-c', script, doc_json, schema_json],
-        capture_output=True, text=True
-    )
-    if result.returncode != 0:
-        raise ValueError(result.stderr)
-
-
-def validate_expect_failure(document, schema, match):
-    """Assert that validation fails with an error matching the given string."""
-    with pytest.raises(ValueError, match=match):
-        validate(document, schema)
 
 
 class TestCivInstancesSchema:
@@ -96,11 +70,8 @@ class TestCivInstancesSchema:
         }
     }
 
-    def test_schema_is_valid_json(self, schema):
-        assert schema.get('$schema') is not None
-        assert schema.get('type') == 'object'
-        assert '$defs' in schema
-        assert 'instance' in schema['$defs']
+    def test_schema_is_valid_json_schema(self, schema):
+        jsonschema.Draft202012Validator.check_schema(schema)
 
     def test_schema_required_fields(self, schema):
         instance_def = schema['$defs']['instance']
@@ -117,16 +88,16 @@ class TestCivInstancesSchema:
             assert 'description' in field_def, f"Field '{field_name}' missing description"
 
     def test_valid_minimal_document(self, schema):
-        validate(self.valid_minimal_document, schema)
+        jsonschema.validate(self.valid_minimal_document, schema)
 
     def test_valid_full_document(self, schema):
-        validate(self.valid_full_document, schema)
+        jsonschema.validate(self.valid_full_document, schema)
 
     def test_valid_multi_instance(self, schema):
-        validate(self.valid_multi_instance_document, schema)
+        jsonschema.validate(self.valid_multi_instance_document, schema)
 
     def test_valid_empty_document(self, schema):
-        validate({}, schema)
+        jsonschema.validate({}, schema)
 
     def test_valid_azure_image_as_object(self, schema):
         doc = {
@@ -138,7 +109,7 @@ class TestCivInstancesSchema:
                 "image": {"publisher": "RedHat", "offer": "RHEL", "sku": "9", "version": "latest"}
             }
         }
-        validate(doc, schema)
+        jsonschema.validate(doc, schema)
 
     def test_invalid_missing_required_field(self, schema):
         doc = {
@@ -149,7 +120,8 @@ class TestCivInstancesSchema:
                 "image": "RHEL-9.5"
             }
         }
-        validate_expect_failure(doc, schema, "required property")
+        with pytest.raises(jsonschema.ValidationError, match="'name' is a required property"):
+            jsonschema.validate(doc, schema)
 
     def test_invalid_cloud_value(self, schema):
         doc = {
@@ -161,7 +133,8 @@ class TestCivInstancesSchema:
                 "image": "RHEL-9.5"
             }
         }
-        validate_expect_failure(doc, schema, "is not one of")
+        with pytest.raises(jsonschema.ValidationError, match="'digitalocean' is not one of"):
+            jsonschema.validate(doc, schema)
 
     def test_invalid_name_type(self, schema):
         doc = {
@@ -173,7 +146,9 @@ class TestCivInstancesSchema:
                 "image": "RHEL-9.5"
             }
         }
-        validate_expect_failure(doc, schema, "is not of type")
+        with pytest.raises(jsonschema.ValidationError, match="is not of type 'string'"):
+            jsonschema.validate(doc, schema)
 
     def test_invalid_top_level_not_object(self, schema):
-        validate_expect_failure(["not", "an", "object"], schema, "is not of type")
+        with pytest.raises(jsonschema.ValidationError, match="is not of type 'object'"):
+            jsonschema.validate(["not", "an", "object"], schema)


### PR DESCRIPTION
Formalizes the implicit instance data format written by cloud_image_validator.py as a JSON Schema, enabling downstream consumers to validate and document the expected fields.

[CLOUDX-2046](https://redhat.atlassian.net/browse/CLOUDX-2046)

[CLOUDX-2046]: https://redhat.atlassian.net/browse/CLOUDX-2046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ