### PR TITLE
Civ 006 junit xsd schema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ paramiko==3.4.1
 requests==2.32.3
 packaging==24.1
 jsonschema==4.23.0
+lxml==5.3.1

--- a/schemas/junit.xsd
+++ b/schemas/junit.xsd
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JUnit XML Schema Definition for CIV result validation.
+
+  Based on the widely-used Windyroad JUnit Schema
+  (https://github.com/windyroad/JUnit-Schema) with relaxed constraints
+  to accept output from pytest - -junit-xml, which omits some elements
+  and attributes that the strict schema requires.
+
+  Copyright (c) 2011, Windy Road Technology Pty. Limited
+  Licensed under the Apache License Version 2.0
+-->
+<xs:schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    attributeFormDefault="unqualified">
+
+    <xs:element name="testsuites">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Contains an aggregation of testsuite results</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+            <xs:attribute name="tests" type="xs:int" use="optional"/>
+            <xs:attribute name="failures" type="xs:int" use="optional"/>
+            <xs:attribute name="errors" type="xs:int" use="optional"/>
+            <xs:attribute name="skipped" type="xs:int" use="optional"/>
+            <xs:attribute name="time" type="xs:decimal" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Contains the results of executing a testsuite</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="properties" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">Properties set during test execution</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:attribute name="name" type="xs:string" use="required"/>
+                                    <xs:attribute name="value" type="xs:string" use="required"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="skipped" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation xml:lang="en">Indicates that the test was skipped</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="message" type="xs:string" use="optional"/>
+                                    <xs:attribute name="type" type="xs:string" use="optional"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="error" minOccurs="0" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation xml:lang="en">Indicates that the test errored</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="message" type="xs:string" use="optional"/>
+                                    <xs:attribute name="type" type="xs:string" use="optional"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="failure" minOccurs="0" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation xml:lang="en">Indicates that the test failed</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="message" type="xs:string" use="optional"/>
+                                    <xs:attribute name="type" type="xs:string" use="optional"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="system-out" type="xs:string" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation xml:lang="en">Stdout captured during test execution</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="system-err" type="xs:string" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation xml:lang="en">Stderr captured during test execution</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="name" type="xs:string" use="required"/>
+                        <xs:attribute name="classname" type="xs:string" use="optional"/>
+                        <xs:attribute name="time" type="xs:decimal" use="optional"/>
+                        <xs:attribute name="file" type="xs:string" use="optional"/>
+                        <xs:attribute name="line" type="xs:int" use="optional"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="system-out" type="xs:string" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">Stdout captured during suite execution</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="system-err" type="xs:string" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">Stderr captured during suite execution</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:int" use="optional"/>
+            <xs:attribute name="failures" type="xs:int" use="optional"/>
+            <xs:attribute name="errors" type="xs:int" use="optional"/>
+            <xs:attribute name="skipped" type="xs:int" use="optional"/>
+            <xs:attribute name="time" type="xs:decimal" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
+            <xs:attribute name="hostname" type="xs:string" use="optional"/>
+            <xs:attribute name="id" type="xs:int" use="optional"/>
+            <xs:attribute name="package" type="xs:string" use="optional"/>
+            <xs:attribute name="file" type="xs:string" use="optional"/>
+            <xs:attribute name="log" type="xs:string" use="optional"/>
+            <xs:attribute name="url" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>

--- a/test/test_schema_validation.py
+++ b/test/test_schema_validation.py
@@ -74,6 +74,27 @@ MALFORMED_MISSING_TESTCASE_NAME = """\
 </testsuites>
 """
 
+MALFORMED_EXTRA_ELEMENT_IN_TESTCASE = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="suite" errors="0" failures="0" tests="1" time="0.001">
+        <testcase classname="test_x" name="test_a" time="0.001">
+            <bogus>unexpected element</bogus>
+        </testcase>
+    </testsuite>
+</testsuites>
+"""
+
+MALFORMED_EXTRA_ELEMENT_IN_TESTSUITE = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="suite" errors="0" failures="0" tests="1" time="0.001">
+        <unknown-element />
+        <testcase classname="test_x" name="test_a" time="0.001" />
+    </testsuite>
+</testsuites>
+"""
+
 MALFORMED_NOT_XML = "this is not xml at all"
 
 
@@ -100,6 +121,14 @@ class TestJunitXsd:
 
     def test_invalid_missing_testcase_name(self, xsd_schema):
         doc = etree.fromstring(MALFORMED_MISSING_TESTCASE_NAME.encode())
+        assert not xsd_schema.validate(doc)
+
+    def test_invalid_extra_element_in_testcase(self, xsd_schema):
+        doc = etree.fromstring(MALFORMED_EXTRA_ELEMENT_IN_TESTCASE.encode())
+        assert not xsd_schema.validate(doc)
+
+    def test_invalid_extra_element_in_testsuite(self, xsd_schema):
+        doc = etree.fromstring(MALFORMED_EXTRA_ELEMENT_IN_TESTSUITE.encode())
         assert not xsd_schema.validate(doc)
 
     def test_invalid_not_xml(self):

--- a/test/test_schema_validation.py
+++ b/test/test_schema_validation.py
@@ -1,0 +1,126 @@
+import os
+import subprocess
+import tempfile
+
+import pytest
+from lxml import etree
+
+
+XSD_PATH = os.path.join(os.path.dirname(__file__), '..', 'schemas', 'junit.xsd')
+
+
+@pytest.fixture
+def xsd_schema():
+    return etree.XMLSchema(etree.parse(XSD_PATH))
+
+
+VALID_JUNIT_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="pytest" errors="0" failures="1" skipped="1" tests="3"
+               time="0.042" timestamp="2026-08-13T13:58:14.911738" hostname="fedora">
+        <testcase classname="test_sample" name="test_pass" time="0.001" />
+        <testcase classname="test_sample" name="test_fail" time="0.002">
+            <failure message="AssertionError: expected failure">
+                assert False
+            </failure>
+        </testcase>
+        <testcase classname="test_sample" name="test_skip" time="0.000">
+            <skipped type="pytest.skip" message="not applicable" />
+        </testcase>
+    </testsuite>
+</testsuites>
+"""
+
+VALID_JUNIT_WITH_ERROR = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="pytest" errors="1" failures="0" skipped="0" tests="1"
+               time="0.010" timestamp="2026-08-13T14:00:00" hostname="ci-runner">
+        <testcase classname="test_err" name="test_runtime_error" time="0.005">
+            <error message="RuntimeError: boom" type="RuntimeError">
+                Traceback ...
+            </error>
+        </testcase>
+        <system-out>some stdout</system-out>
+        <system-err>some stderr</system-err>
+    </testsuite>
+</testsuites>
+"""
+
+VALID_EMPTY_SUITE = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="empty" tests="0" errors="0" failures="0" time="0.000">
+    </testsuite>
+</testsuites>
+"""
+
+MALFORMED_MISSING_NAME = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite errors="0" failures="0" tests="1" time="0.001">
+        <testcase classname="test_x" name="test_a" time="0.001" />
+    </testsuite>
+</testsuites>
+"""
+
+MALFORMED_MISSING_TESTCASE_NAME = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="suite" errors="0" failures="0" tests="1" time="0.001">
+        <testcase classname="test_x" time="0.001" />
+    </testsuite>
+</testsuites>
+"""
+
+MALFORMED_NOT_XML = "this is not xml at all"
+
+
+class TestJunitXsd:
+
+    def test_xsd_is_valid_schema(self):
+        etree.XMLSchema(etree.parse(XSD_PATH))
+
+    def test_valid_junit_xml(self, xsd_schema):
+        doc = etree.fromstring(VALID_JUNIT_XML.encode())
+        assert xsd_schema.validate(doc)
+
+    def test_valid_junit_with_error_and_system_output(self, xsd_schema):
+        doc = etree.fromstring(VALID_JUNIT_WITH_ERROR.encode())
+        assert xsd_schema.validate(doc)
+
+    def test_valid_empty_suite(self, xsd_schema):
+        doc = etree.fromstring(VALID_EMPTY_SUITE.encode())
+        assert xsd_schema.validate(doc)
+
+    def test_invalid_missing_testsuite_name(self, xsd_schema):
+        doc = etree.fromstring(MALFORMED_MISSING_NAME.encode())
+        assert not xsd_schema.validate(doc)
+
+    def test_invalid_missing_testcase_name(self, xsd_schema):
+        doc = etree.fromstring(MALFORMED_MISSING_TESTCASE_NAME.encode())
+        assert not xsd_schema.validate(doc)
+
+    def test_invalid_not_xml(self):
+        with pytest.raises(etree.XMLSyntaxError):
+            etree.fromstring(MALFORMED_NOT_XML.encode())
+
+    def test_pytest_junit_xml_output(self, xsd_schema):
+        test_file = os.path.join(os.path.dirname(__file__), '_sample_for_junit.py')
+        with open(test_file, 'w') as f:
+            f.write("def test_pass(): assert True\n")
+        try:
+            with tempfile.NamedTemporaryFile(suffix='.xml', delete=False) as tmp:
+                xml_path = tmp.name
+            subprocess.run(
+                ['pytest', test_file, f'--junit-xml={xml_path}', '-q',
+                 f'--rootdir={os.path.dirname(test_file)}'],
+                capture_output=True, check=True
+            )
+            doc = etree.parse(xml_path)
+            assert xsd_schema.validate(doc), xsd_schema.error_log
+        finally:
+            for p in [test_file, xml_path]:
+                if os.path.exists(p):
+                    os.unlink(p)


### PR DESCRIPTION
  ## Summary
  - Adds `schemas/junit.xsd`: JUnit XML Schema Definition based on the Windyroad standard, relaxed to accept `pytest --junit-xml` output
  - Covers standard elements: `testsuites`, `testsuite`, `testcase`, `failure`, `error`, `skipped`, `system-out`, `system-err`
  - Adds `lxml==5.3.1` and `jsonschema==4.23.0` to `requirements.txt`
  - 8 unit tests: valid XML (pass/fail/skip/error/system-output), empty suite, rejection of malformed XML, and live pytest output validation

  ## Test plan
  - [x] XSD validates correct JUnit XML samples
  - [x] XSD rejects malformed XML (missing required attributes)
  - [x] Live `pytest --junit-xml` output passes validation

[  CLOUDX-2047
](https://redhat.atlassian.net/browse/CLOUDX-2047)