### PR TITLE
Civ 008 junit validation aggregation

### DIFF
--- a/core/results.py
+++ b/core/results.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from lxml import etree
+
+_XSD_PATH = Path(__file__).resolve().parent.parent / 'schemas' / 'junit.xsd'
+
+
+class ResultValidationError(Exception):
+    pass
+
+
+@dataclass
+class MergeResult:
+    total_tests: int
+    failures: int
+    errors: int
+    skipped: int
+    time: float
+
+
+def _load_xsd() -> etree.XMLSchema:
+    return etree.XMLSchema(etree.parse(str(_XSD_PATH)))
+
+
+def validate_junit_xml(path: str) -> bool:
+    try:
+        doc = etree.parse(path)
+    except etree.XMLSyntaxError as exc:
+        raise ResultValidationError(f"Malformed XML in {path}: {exc}") from exc
+
+    schema = _load_xsd()
+    if not schema.validate(doc):
+        errors = "; ".join(str(e) for e in schema.error_log)
+        raise ResultValidationError(f"XSD validation failed for {path}: {errors}")
+
+    return True
+
+
+def merge_results(
+    result_paths: list[str],
+    output_path: str,
+    instance_labels: list[str] | None = None,
+) -> MergeResult:
+    if instance_labels and len(instance_labels) != len(result_paths):
+        raise ValueError("instance_labels must match the length of result_paths")
+
+    schema = _load_xsd()
+    merged_root = etree.Element("testsuites")
+    total_tests = 0
+    total_failures = 0
+    total_errors = 0
+    total_skipped = 0
+    total_time = 0.0
+
+    for i, path in enumerate(result_paths):
+        try:
+            doc = etree.parse(path)
+        except etree.XMLSyntaxError as exc:
+            raise ResultValidationError(f"Malformed XML in {path}: {exc}") from exc
+
+        if not schema.validate(doc):
+            errors = "; ".join(str(e) for e in schema.error_log)
+            raise ResultValidationError(f"XSD validation failed for {path}: {errors}")
+
+        root = doc.getroot()
+        label = instance_labels[i] if instance_labels else None
+
+        if root.tag == "testsuites":
+            suites = root.findall("testsuite")
+        elif root.tag == "testsuite":
+            suites = [root]
+        else:
+            raise ResultValidationError(
+                f"Unexpected root element <{root.tag}> in {path}"
+            )
+
+        for suite in suites:
+            if label:
+                original_name = suite.get("name", "")
+                suite.set("name", f"{label}.{original_name}")
+
+            total_tests += int(suite.get("tests", 0))
+            total_failures += int(suite.get("failures", 0))
+            total_errors += int(suite.get("errors", 0))
+            total_skipped += int(suite.get("skipped", 0))
+            total_time += float(suite.get("time", 0.0))
+
+            merged_root.append(suite)
+
+    tree = etree.ElementTree(merged_root)
+    tree.write(output_path, xml_declaration=True, encoding="utf-8", pretty_print=True)
+
+    return MergeResult(
+        total_tests=total_tests,
+        failures=total_failures,
+        errors=total_errors,
+        skipped=total_skipped,
+        time=round(total_time, 3),
+    )
+
+
+def get_exit_code(merge_result: MergeResult) -> int:
+    if merge_result.errors > 0:
+        return 2
+    if merge_result.failures > 0:
+        return 1
+    return 0

--- a/core/results.py
+++ b/core/results.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from lxml import etree
 
 _XSD_PATH = Path(__file__).resolve().parent.parent / 'schemas' / 'junit.xsd'
+_SAFE_PARSER = etree.XMLParser(resolve_entities=False, no_network=True)
 
 
 class ResultValidationError(Exception):
@@ -25,18 +26,21 @@ def _load_xsd() -> etree.XMLSchema:
     return etree.XMLSchema(etree.parse(str(_XSD_PATH)))
 
 
-def validate_junit_xml(path: str) -> bool:
+def _parse_and_validate(path: str, schema: etree.XMLSchema) -> etree._ElementTree:
     try:
-        doc = etree.parse(path)
+        doc = etree.parse(path, parser=_SAFE_PARSER)
     except etree.XMLSyntaxError as exc:
         raise ResultValidationError(f"Malformed XML in {path}: {exc}") from exc
 
-    schema = _load_xsd()
     if not schema.validate(doc):
         errors = "; ".join(str(e) for e in schema.error_log)
         raise ResultValidationError(f"XSD validation failed for {path}: {errors}")
 
-    return True
+    return doc
+
+
+def validate_junit_xml(path: str) -> None:
+    _parse_and_validate(path, _load_xsd())
 
 
 def merge_results(
@@ -44,7 +48,7 @@ def merge_results(
     output_path: str,
     instance_labels: list[str] | None = None,
 ) -> MergeResult:
-    if instance_labels and len(instance_labels) != len(result_paths):
+    if instance_labels is not None and len(instance_labels) != len(result_paths):
         raise ValueError("instance_labels must match the length of result_paths")
 
     schema = _load_xsd()
@@ -56,17 +60,9 @@ def merge_results(
     total_time = 0.0
 
     for i, path in enumerate(result_paths):
-        try:
-            doc = etree.parse(path)
-        except etree.XMLSyntaxError as exc:
-            raise ResultValidationError(f"Malformed XML in {path}: {exc}") from exc
-
-        if not schema.validate(doc):
-            errors = "; ".join(str(e) for e in schema.error_log)
-            raise ResultValidationError(f"XSD validation failed for {path}: {errors}")
-
+        doc = _parse_and_validate(path, schema)
         root = doc.getroot()
-        label = instance_labels[i] if instance_labels else None
+        label = instance_labels[i] if instance_labels is not None else None
 
         if root.tag == "testsuites":
             suites = root.findall("testsuite")

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -1,0 +1,268 @@
+import os
+
+import pytest
+from lxml import etree
+
+from core.results import (
+    MergeResult,
+    ResultValidationError,
+    get_exit_code,
+    merge_results,
+    validate_junit_xml,
+)
+
+
+VALID_SINGLE_SUITE = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="pytest" errors="0" failures="0" skipped="0" tests="2"
+               time="0.050" timestamp="2026-08-18T10:00:00" hostname="host1">
+        <testcase classname="test_generic" name="test_pass_1" time="0.020" />
+        <testcase classname="test_generic" name="test_pass_2" time="0.030" />
+    </testsuite>
+</testsuites>
+"""
+
+VALID_WITH_FAILURE = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="pytest" errors="0" failures="1" skipped="0" tests="2"
+               time="0.040" timestamp="2026-08-18T10:00:00" hostname="host1">
+        <testcase classname="test_generic" name="test_pass" time="0.010" />
+        <testcase classname="test_generic" name="test_fail" time="0.030">
+            <failure message="assert False">assert False</failure>
+        </testcase>
+    </testsuite>
+</testsuites>
+"""
+
+VALID_WITH_ERROR = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="pytest" errors="1" failures="0" skipped="0" tests="1"
+               time="0.010" timestamp="2026-08-18T10:00:00" hostname="host1">
+        <testcase classname="test_generic" name="test_err" time="0.010">
+            <error message="RuntimeError" type="RuntimeError">traceback</error>
+        </testcase>
+    </testsuite>
+</testsuites>
+"""
+
+VALID_WITH_SKIP = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="pytest" errors="0" failures="0" skipped="1" tests="1"
+               time="0.001" timestamp="2026-08-18T10:00:00" hostname="host1">
+        <testcase classname="test_generic" name="test_skip" time="0.001">
+            <skipped message="not applicable" />
+        </testcase>
+    </testsuite>
+</testsuites>
+"""
+
+VALID_EMPTY_SUITE = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="pytest" errors="0" failures="0" skipped="0" tests="0"
+               time="0.000" timestamp="2026-08-18T10:00:00" hostname="host1">
+    </testsuite>
+</testsuites>
+"""
+
+VALID_BARE_TESTSUITE = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuite name="pytest" errors="0" failures="0" skipped="0" tests="1"
+           time="0.010" timestamp="2026-08-18T10:00:00" hostname="host1">
+    <testcase classname="test_generic" name="test_a" time="0.010" />
+</testsuite>
+"""
+
+INVALID_XML = "this is not xml"
+
+INVALID_SCHEMA = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite errors="0" failures="0" tests="1" time="0.001">
+        <testcase classname="test_x" name="test_a" time="0.001" />
+    </testsuite>
+</testsuites>
+"""
+
+
+def _write_xml(tmp_path: str, filename: str, content: str) -> str:
+    path = os.path.join(tmp_path, filename)
+    with open(path, 'w') as f:
+        f.write(content)
+    return path
+
+
+class TestValidateJunitXml:
+
+    def test_valid_file(self, tmp_path):
+        path = _write_xml(str(tmp_path), 'valid.xml', VALID_SINGLE_SUITE)
+        assert validate_junit_xml(path) is True
+
+    def test_valid_bare_testsuite(self, tmp_path):
+        path = _write_xml(str(tmp_path), 'bare.xml', VALID_BARE_TESTSUITE)
+        assert validate_junit_xml(path) is True
+
+    def test_malformed_xml_raises(self, tmp_path):
+        path = _write_xml(str(tmp_path), 'bad.xml', INVALID_XML)
+        with pytest.raises(ResultValidationError, match="Malformed XML"):
+            validate_junit_xml(path)
+
+    def test_schema_violation_raises(self, tmp_path):
+        path = _write_xml(str(tmp_path), 'invalid.xml', INVALID_SCHEMA)
+        with pytest.raises(ResultValidationError, match="XSD validation failed"):
+            validate_junit_xml(path)
+
+    def test_nonexistent_file_raises(self):
+        with pytest.raises(OSError):
+            validate_junit_xml('/nonexistent/path.xml')
+
+
+class TestMergeResults:
+
+    def test_single_file(self, tmp_path):
+        src = _write_xml(str(tmp_path), 'result.xml', VALID_SINGLE_SUITE)
+        out = str(tmp_path / 'merged.xml')
+
+        result = merge_results([src], out)
+
+        assert result.total_tests == 2
+        assert result.failures == 0
+        assert result.errors == 0
+        assert result.skipped == 0
+        assert os.path.exists(out)
+
+    def test_multiple_files(self, tmp_path):
+        src1 = _write_xml(str(tmp_path), 'r1.xml', VALID_SINGLE_SUITE)
+        src2 = _write_xml(str(tmp_path), 'r2.xml', VALID_WITH_FAILURE)
+        out = str(tmp_path / 'merged.xml')
+
+        result = merge_results([src1, src2], out)
+
+        assert result.total_tests == 4
+        assert result.failures == 1
+        assert result.errors == 0
+
+    def test_merged_output_is_valid_xml(self, tmp_path):
+        src1 = _write_xml(str(tmp_path), 'r1.xml', VALID_SINGLE_SUITE)
+        src2 = _write_xml(str(tmp_path), 'r2.xml', VALID_WITH_FAILURE)
+        out = str(tmp_path / 'merged.xml')
+
+        merge_results([src1, src2], out)
+
+        doc = etree.parse(out)
+        root = doc.getroot()
+        assert root.tag == "testsuites"
+        assert len(root.findall("testsuite")) == 2
+
+    def test_instance_labels_prefix_suite_names(self, tmp_path):
+        src1 = _write_xml(str(tmp_path), 'r1.xml', VALID_SINGLE_SUITE)
+        src2 = _write_xml(str(tmp_path), 'r2.xml', VALID_WITH_FAILURE)
+        out = str(tmp_path / 'merged.xml')
+
+        merge_results([src1, src2], out, instance_labels=['instance-1', 'instance-2'])
+
+        doc = etree.parse(out)
+        names = [s.get("name") for s in doc.getroot().findall("testsuite")]
+        assert names == ['instance-1.pytest', 'instance-2.pytest']
+
+    def test_instance_labels_length_mismatch_raises(self, tmp_path):
+        src = _write_xml(str(tmp_path), 'r1.xml', VALID_SINGLE_SUITE)
+        out = str(tmp_path / 'merged.xml')
+
+        with pytest.raises(ValueError, match="instance_labels must match"):
+            merge_results([src], out, instance_labels=['a', 'b'])
+
+    def test_empty_suite(self, tmp_path):
+        src = _write_xml(str(tmp_path), 'empty.xml', VALID_EMPTY_SUITE)
+        out = str(tmp_path / 'merged.xml')
+
+        result = merge_results([src], out)
+
+        assert result.total_tests == 0
+        assert result.failures == 0
+
+    def test_bare_testsuite_without_wrapper(self, tmp_path):
+        src = _write_xml(str(tmp_path), 'bare.xml', VALID_BARE_TESTSUITE)
+        out = str(tmp_path / 'merged.xml')
+
+        result = merge_results([src], out)
+
+        assert result.total_tests == 1
+        doc = etree.parse(out)
+        assert doc.getroot().tag == "testsuites"
+
+    def test_invalid_file_raises(self, tmp_path):
+        src = _write_xml(str(tmp_path), 'bad.xml', INVALID_XML)
+        out = str(tmp_path / 'merged.xml')
+
+        with pytest.raises(ResultValidationError, match="Malformed XML"):
+            merge_results([src], out)
+
+    def test_schema_violation_raises(self, tmp_path):
+        src = _write_xml(str(tmp_path), 'invalid.xml', INVALID_SCHEMA)
+        out = str(tmp_path / 'merged.xml')
+
+        with pytest.raises(ResultValidationError, match="XSD validation failed"):
+            merge_results([src], out)
+
+    def test_empty_paths_list(self, tmp_path):
+        out = str(tmp_path / 'merged.xml')
+
+        result = merge_results([], out)
+
+        assert result.total_tests == 0
+        assert result.failures == 0
+        assert os.path.exists(out)
+
+    def test_time_accumulation(self, tmp_path):
+        src1 = _write_xml(str(tmp_path), 'r1.xml', VALID_SINGLE_SUITE)
+        src2 = _write_xml(str(tmp_path), 'r2.xml', VALID_WITH_FAILURE)
+        out = str(tmp_path / 'merged.xml')
+
+        result = merge_results([src1, src2], out)
+
+        assert result.time == 0.09
+
+    def test_mixed_results(self, tmp_path):
+        src1 = _write_xml(str(tmp_path), 'r1.xml', VALID_WITH_FAILURE)
+        src2 = _write_xml(str(tmp_path), 'r2.xml', VALID_WITH_ERROR)
+        src3 = _write_xml(str(tmp_path), 'r3.xml', VALID_WITH_SKIP)
+        out = str(tmp_path / 'merged.xml')
+
+        result = merge_results([src1, src2, src3], out)
+
+        assert result.total_tests == 4
+        assert result.failures == 1
+        assert result.errors == 1
+        assert result.skipped == 1
+
+
+class TestGetExitCode:
+
+    def test_all_pass(self):
+        result = MergeResult(total_tests=10, failures=0, errors=0, skipped=0, time=1.0)
+        assert get_exit_code(result) == 0
+
+    def test_with_failures(self):
+        result = MergeResult(total_tests=10, failures=2, errors=0, skipped=0, time=1.0)
+        assert get_exit_code(result) == 1
+
+    def test_with_errors(self):
+        result = MergeResult(total_tests=10, failures=0, errors=1, skipped=0, time=1.0)
+        assert get_exit_code(result) == 2
+
+    def test_errors_take_precedence_over_failures(self):
+        result = MergeResult(total_tests=10, failures=3, errors=1, skipped=0, time=1.0)
+        assert get_exit_code(result) == 2
+
+    def test_skipped_only_is_pass(self):
+        result = MergeResult(total_tests=5, failures=0, errors=0, skipped=5, time=0.5)
+        assert get_exit_code(result) == 0
+
+    def test_empty_result(self):
+        result = MergeResult(total_tests=0, failures=0, errors=0, skipped=0, time=0.0)
+        assert get_exit_code(result) == 0

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -229,7 +229,7 @@ class TestMergeResults:
         src = _write_xml(str(tmp_path), 'bad_root.xml', INVALID_ROOT_ELEMENT)
         out = str(tmp_path / 'merged.xml')
 
-        with pytest.raises(ResultValidationError, match="Unexpected root element"):
+        with pytest.raises(ResultValidationError, match="XSD validation failed"):
             merge_results([src], out)
 
     def test_empty_paths_list(self, tmp_path):

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -77,6 +77,15 @@ VALID_BARE_TESTSUITE = """\
 </testsuite>
 """
 
+INVALID_ROOT_ELEMENT = """\
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+    <testsuite name="pytest" errors="0" failures="0" tests="1" time="0.001">
+        <testcase classname="test_x" name="test_a" time="0.001" />
+    </testsuite>
+</root>
+"""
+
 INVALID_XML = "this is not xml"
 
 INVALID_SCHEMA = """\
@@ -100,11 +109,11 @@ class TestValidateJunitXml:
 
     def test_valid_file(self, tmp_path):
         path = _write_xml(str(tmp_path), 'valid.xml', VALID_SINGLE_SUITE)
-        assert validate_junit_xml(path) is True
+        validate_junit_xml(path)
 
     def test_valid_bare_testsuite(self, tmp_path):
         path = _write_xml(str(tmp_path), 'bare.xml', VALID_BARE_TESTSUITE)
-        assert validate_junit_xml(path) is True
+        validate_junit_xml(path)
 
     def test_malformed_xml_raises(self, tmp_path):
         path = _write_xml(str(tmp_path), 'bad.xml', INVALID_XML)
@@ -176,6 +185,13 @@ class TestMergeResults:
         with pytest.raises(ValueError, match="instance_labels must match"):
             merge_results([src], out, instance_labels=['a', 'b'])
 
+    def test_empty_instance_labels_raises(self, tmp_path):
+        src = _write_xml(str(tmp_path), 'r1.xml', VALID_SINGLE_SUITE)
+        out = str(tmp_path / 'merged.xml')
+
+        with pytest.raises(ValueError, match="instance_labels must match"):
+            merge_results([src], out, instance_labels=[])
+
     def test_empty_suite(self, tmp_path):
         src = _write_xml(str(tmp_path), 'empty.xml', VALID_EMPTY_SUITE)
         out = str(tmp_path / 'merged.xml')
@@ -207,6 +223,13 @@ class TestMergeResults:
         out = str(tmp_path / 'merged.xml')
 
         with pytest.raises(ResultValidationError, match="XSD validation failed"):
+            merge_results([src], out)
+
+    def test_unexpected_root_element_raises(self, tmp_path):
+        src = _write_xml(str(tmp_path), 'bad_root.xml', INVALID_ROOT_ELEMENT)
+        out = str(tmp_path / 'merged.xml')
+
+        with pytest.raises(ResultValidationError, match="Unexpected root element"):
             merge_results([src], out)
 
     def test_empty_paths_list(self, tmp_path):


### PR DESCRIPTION
## Summary
  - Adds `core/results.py` with JUnit XML validation, multi-file merge, and exit code logic
  - `validate_junit_xml()` validates against `schemas/junit.xsd`, raises `ResultValidationError` with descriptive messages
  - `merge_results()` merges N JUnit XML files into one `<testsuites>` document, prefixing suite names with instance labels
  - `get_exit_code()` returns `0` (all pass), `1` (failures), or `2` (errors) per ADR convention
  - Handles edge cases: bare `<testsuite>` without wrapper, empty suites, mixed formats
  - 100% type hint coverage on all public APIs

  ## Test plan
  - [x] Valid single-file validation
  - [x] Multiple files merged with correct counter aggregation
  - [x] Instance labels prefix testsuite names
  - [x] Invalid/malformed XML raises `ResultValidationError`
  - [x] Empty result (0 test cases)
  - [x] Bare `<testsuite>` without `<testsuites>` wrapper
  - [x] Exit code 0/1/2 for pass/failure/error scenarios
  - [x] Errors take precedence over failures in exit code

[  CLOUDX-2049](https://redhat.atlassian.net/browse/CLOUDX-2049)