### PR TITLE
change test_yum_plugins to run only for 3p images

### DIFF
--- a/cloud/opentofu/opentofu_configurator.py
+++ b/cloud/opentofu/opentofu_configurator.py
@@ -100,3 +100,10 @@ class OpenTofuConfigurator:
             if sanitized in tf_resource_name:
                 return instance['username']
         raise Exception(f'ERROR: No OCI instance matching tf resource name "{tf_resource_name}" was found')
+
+    def get_image_type(self):
+        """
+        Return the image_type from the top-level resource config.
+        Defaults to '1p' (first-party) if not specified.
+        """
+        return self.resources_dict.get('image_type', '1p')

--- a/cloud/opentofu/opentofu_controller.py
+++ b/cloud/opentofu/opentofu_controller.py
@@ -99,6 +99,7 @@ class OpenTofuController:
                 'ami': ami_name,
                 'image': ami_name,
                 'username': username,
+                'image_type': self.tf_configurator.get_image_type(),
             }
 
             self._set_instance_default_address(instance_data)
@@ -132,6 +133,7 @@ class OpenTofuController:
                 'location': res['values']['location'],
                 'image': image,
                 'username': res['values']['admin_username'],
+                'image_type': self.tf_configurator.get_image_type(),
             }
 
             self._set_instance_default_address(instance_data)
@@ -160,6 +162,7 @@ class OpenTofuController:
                 'zone': resource['values']['zone'],
                 'image': resource['values']['metadata']['image'],
                 'username': resource['values']['metadata']['username'],
+                'image_type': self.tf_configurator.get_image_type(),
             }
 
         return instances_info
@@ -186,6 +189,7 @@ class OpenTofuController:
                 'shape': values['shape'],
                 'image': values['source_details'][0]['source_id'],
                 'username': self.tf_configurator.get_oci_username_by_instance_name(resource['name']),
+                'image_type': self.tf_configurator.get_image_type(),
             }
 
             self._set_instance_default_address(instance_data)

--- a/cloud/sample/resources_aws_marketplace.json
+++ b/cloud/sample/resources_aws_marketplace.json
@@ -1,5 +1,6 @@
 {
   "provider": "aws",
+  "image_type": "1p",
   "instances": [
     {
       "ami": "ami-03724163927725aeb",

--- a/cloud/sample/resources_oci.json
+++ b/cloud/sample/resources_oci.json
@@ -1,6 +1,7 @@
 {
   "provider": "oci",
   "profile": "DEFAULT",
+  "image_type": "3p",
   "instances": [
     {
       "image_id": "ocid1.image.oc1.us-sanjose-1.aaaaaaaamb7egvv2k4pslulaezw5dtgwx4f6js7fmapkjq4df2m2dqhtfbsq",

--- a/test/test_opentofu_controller.py
+++ b/test/test_opentofu_controller.py
@@ -100,11 +100,14 @@ class TestOpenTofuController:
                 'ami': 'test_ami',
                 'image': 'test_ami',
                 'username': 'test_user',
+                'image_type': '1p',
             }
         }
 
         mock_get_aws_username_by_ami_name = mocker.MagicMock(return_value='test_user')
         self.tf_configurator.get_aws_username_by_ami_name = mock_get_aws_username_by_ami_name
+
+        self.tf_configurator.get_image_type.return_value = '1p'
 
         # Act
         result = tf_controller.get_instances_aws(resources)
@@ -160,6 +163,7 @@ class TestOpenTofuController:
                 'location': test_location,
                 'image': test_image,
                 'username': test_username,
+                'image_type': '1p',
             }
         }
 
@@ -170,6 +174,8 @@ class TestOpenTofuController:
         mock_get_azure_image_data_from_resource = mocker.patch.object(tf_controller,
                                                                       '_get_azure_image_data_from_resource',
                                                                       return_value=test_image)
+
+        self.tf_configurator.get_image_type.return_value = '1p'
 
         # Act
         result = tf_controller.get_instances_azure(resources)
@@ -225,8 +231,11 @@ class TestOpenTofuController:
                 'zone': test_zone,
                 'image': test_image,
                 'username': test_username,
+                'image_type': '1p',
             }
         }
+
+        self.tf_configurator.get_image_type.return_value = '1p'
 
         # Act
         result = tf_controller.get_instances_gcloud(resources)

--- a/test_suite/conftest.py
+++ b/test_suite/conftest.py
@@ -166,6 +166,13 @@ def rhel_aws_marketplace_only(host, instance_data):
         pytest.skip('Not applicable to RHEL AWS Stratosphere images.')
 
 
+@pytest.fixture
+def third_party_only(instance_data):
+    """Skip test if the image is not a third-party (3p) image."""
+    if instance_data.get('image_type', '1p') != '3p':
+        pytest.skip('Only applicable to third-party (3p) images.')
+
+
 @pytest.fixture(scope='module', autouse=True)
 def instance_data(host):
     values_to_find = [host.backend.hostname]

--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -769,10 +769,12 @@ class TestsGeneric:
                 f'There should be {num_of_gpg_keys} gpg key(s) installed in the pqrpm db'
 
     @pytest.mark.run_on(['rhel'])
+    @pytest.mark.usefixtures('third_party_only')
     def test_yum_plugins(self, host):
         """
         BugZilla 1932802
         Verify yum/dnf product-id and subscription-manager plugins are enabled for RHEL 8.4+.
+        This test only applies to third-party (3p) images.
         """
         expect_config = "enabled=1"
 


### PR DESCRIPTION
Adds an option `image_type` in resources.json which takes 1p or 3p.
If the image is 3p, only then the test `test_yum_plugins` runs. Otherwise it skips the test.