### PR TITLE
Update test_auditd checksum for 10.2

### DIFF
--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -562,7 +562,7 @@ class TestsGeneric:
         - Config files should have the correct MD5 checksums
         """
         checksums_by_version = {
-            '10.0+': {
+            '10.3+': {
                 '/etc/audit/auditd.conf': '4620bfd853bcd869f7a2cb8b1c6d715f',
                 '/etc/audit/audit.rules': '795528bd4c7b4131455c15d5d49991bb'
             },
@@ -586,9 +586,9 @@ class TestsGeneric:
             auditd_service).is_running, f'{auditd_service} expected to be running'
 
         system_release = version.parse(host.system_info.release)
-        if system_release >= version.parse('10.0'):
-            checksums = checksums_by_version['10.0+']
-        elif system_release >= version.parse('9.4'):
+        if system_release >= version.parse('10.3'):
+            checksums = checksums_by_version['10.3+']
+        elif system_release >= version.parse('9.4') and system_release <= version.parse('10.2'):
             checksums = checksums_by_version['9.4+']
         elif version.parse('9.0') > system_release >= version.parse('8.10'):
             checksums = checksums_by_version['8.10+']


### PR DESCRIPTION
the checksum for auditd.conf and audit.rules have changed for 10.3 and above. 
10.2 fails as it still has the checksum which 9.4 and above have.