### PR TITLE
fix: narrow auditd checksum to 10.3+ for RHEL 10.2 compatibility

### DIFF
--- a/test_suite/generic/test_generic.py
+++ b/test_suite/generic/test_generic.py
@@ -562,7 +562,7 @@ class TestsGeneric:
         - Config files should have the correct MD5 checksums
         """
         checksums_by_version = {
-            '10.0+': {
+            '10.3+': {
                 '/etc/audit/auditd.conf': '4620bfd853bcd869f7a2cb8b1c6d715f',
                 '/etc/audit/audit.rules': '795528bd4c7b4131455c15d5d49991bb'
             },
@@ -586,8 +586,8 @@ class TestsGeneric:
             auditd_service).is_running, f'{auditd_service} expected to be running'
 
         system_release = version.parse(host.system_info.release)
-        if system_release >= version.parse('10.0'):
-            checksums = checksums_by_version['10.0+']
+        if system_release >= version.parse('10.3'):
+            checksums = checksums_by_version['10.3+']
         elif system_release >= version.parse('9.4'):
             checksums = checksums_by_version['9.4+']
         elif version.parse('9.0') > system_release >= version.parse('8.10'):


### PR DESCRIPTION
## Summary
- RHEL 10.2 uses the same `auditd.conf` checksum as RHEL 9.4+ (`fd5c639b8b1bd57c486dab75985ad9af`), not the one introduced for RHEL 10.3 Beta (`4620bfd853bcd869f7a2cb8b1c6d715f`).
- Narrowed the `10.0+` checksum entry to `10.3+` so RHEL 10.0–10.2 correctly falls through to the `9.4+` checksum.

## Test plan
- [x] Ran `test_auditd` against RHEL 10.2 OCI image (`rhel-lvm-oci-10.2-20260902.1`) — passed