### PR TITLE
feat: add command executor with parallel SSH execution (CIV-012)

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+
+from core.metadata import InstanceMetadata
+
+
+@dataclass
+class InstanceResult:
+    instance_name: str
+    exit_code: int
+    result_file: str | None
+    stdout: str
+    stderr: str
+
+
+@dataclass
+class ExecutionResult:
+    instance_results: list[InstanceResult]
+
+    @property
+    def all_passed(self) -> bool:
+        return all(r.exit_code == 0 for r in self.instance_results)
+
+
+def _run_on_instance(
+    instance: InstanceMetadata,
+    command: str,
+    ssh_config: str,
+    results_dir: str,
+    remote_results_path: str,
+    timeout: int,
+) -> InstanceResult:
+    try:
+        result = subprocess.run(
+            [
+                "ssh",
+                "-F", ssh_config,
+                f"{instance.username}@{instance.address}",
+                command,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        exit_code = result.returncode
+        stdout = result.stdout
+        stderr = result.stderr
+    except subprocess.TimeoutExpired:
+        exit_code = 124
+        stdout = ""
+        stderr = f"SSH command timed out after {timeout} seconds"
+    except Exception as exc:
+        exit_code = 1
+        stdout = ""
+        stderr = str(exc)
+
+    local_result_file = os.path.join(
+        results_dir, f"instance-{instance.name}.xml",
+    )
+    try:
+        scp_result = subprocess.run(
+            [
+                "scp",
+                "-F", ssh_config,
+                f"{instance.username}@{instance.address}:{remote_results_path}",
+                local_result_file,
+            ],
+            capture_output=True,
+            timeout=60,
+        )
+        collected = scp_result.returncode == 0
+    except Exception:
+        collected = False
+
+    return InstanceResult(
+        instance_name=instance.name,
+        exit_code=exit_code,
+        result_file=local_result_file if collected else None,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def execute(
+    instances: dict[str, InstanceMetadata],
+    command: str,
+    ssh_config: str,
+    results_dir: str,
+    timeout: int = 3600,
+    remote_results_path: str = "/tmp/results.xml",
+) -> ExecutionResult:
+    os.makedirs(results_dir, exist_ok=True)
+
+    results: list[InstanceResult] = []
+    with ThreadPoolExecutor(max_workers=len(instances) or 1) as pool:
+        futures = {
+            pool.submit(
+                _run_on_instance,
+                instance=inst,
+                command=command,
+                ssh_config=ssh_config,
+                results_dir=results_dir,
+                remote_results_path=remote_results_path,
+                timeout=timeout,
+            ): key
+            for key, inst in instances.items()
+        }
+
+        for future in as_completed(futures):
+            results.append(future.result())
+
+    return ExecutionResult(instance_results=results)

--- a/core/executor.py
+++ b/core/executor.py
@@ -34,6 +34,7 @@ def _run_on_instance(
     remote_results_path: str,
     timeout: int,
 ) -> InstanceResult:
+    ssh_failed = False
     try:
         result = subprocess.run(
             [
@@ -50,10 +51,12 @@ def _run_on_instance(
         stdout = result.stdout
         stderr = result.stderr
     except subprocess.TimeoutExpired:
+        ssh_failed = True
         exit_code = 124
         stdout = ""
         stderr = f"SSH command timed out after {timeout} seconds"
     except Exception as exc:
+        ssh_failed = True
         exit_code = 1
         stdout = ""
         stderr = str(exc)
@@ -61,20 +64,22 @@ def _run_on_instance(
     local_result_file = os.path.join(
         results_dir, f"instance-{instance.name}.xml",
     )
-    try:
-        scp_result = subprocess.run(
-            [
-                "scp",
-                "-F", ssh_config,
-                f"{instance.username}@{instance.address}:{remote_results_path}",
-                local_result_file,
-            ],
-            capture_output=True,
-            timeout=60,
-        )
-        collected = scp_result.returncode == 0
-    except Exception:
-        collected = False
+    collected = False
+    if not ssh_failed:
+        try:
+            scp_result = subprocess.run(
+                [
+                    "scp",
+                    "-F", ssh_config,
+                    f"{instance.username}@{instance.address}:{remote_results_path}",
+                    local_result_file,
+                ],
+                capture_output=True,
+                timeout=60,
+            )
+            collected = scp_result.returncode == 0
+        except Exception:
+            pass
 
     return InstanceResult(
         instance_name=instance.name,

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -63,11 +63,8 @@ class TestRunOnInstance:
         assert result.stderr == "error"
 
     @patch("core.executor.subprocess.run")
-    def test_timeout_handling(self, mock_run):
-        mock_run.side_effect = [
-            subprocess.TimeoutExpired(cmd="ssh", timeout=10),
-            subprocess.CompletedProcess(args=[], returncode=1),
-        ]
+    def test_timeout_skips_scp(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="ssh", timeout=10)
 
         result = _run_on_instance(
             _make_instance(), "slow-cmd", "/tmp/ssh_config",
@@ -76,13 +73,12 @@ class TestRunOnInstance:
 
         assert result.exit_code == 124
         assert "timed out" in result.stderr
+        assert result.result_file is None
+        assert mock_run.call_count == 1
 
     @patch("core.executor.subprocess.run")
-    def test_ssh_connection_error(self, mock_run):
-        mock_run.side_effect = [
-            Exception("Connection refused"),
-            subprocess.CompletedProcess(args=[], returncode=1),
-        ]
+    def test_ssh_connection_error_skips_scp(self, mock_run):
+        mock_run.side_effect = Exception("Connection refused")
 
         result = _run_on_instance(
             _make_instance(), "cmd", "/tmp/ssh_config",
@@ -91,6 +87,8 @@ class TestRunOnInstance:
 
         assert result.exit_code == 1
         assert "Connection refused" in result.stderr
+        assert result.result_file is None
+        assert mock_run.call_count == 1
 
     @patch("core.executor.subprocess.run")
     def test_scp_failure_sets_result_file_none(self, mock_run):

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -1,0 +1,201 @@
+import subprocess
+from unittest.mock import patch
+
+from core.executor import execute, _run_on_instance, ExecutionResult, InstanceResult
+from core.metadata import InstanceMetadata
+
+
+def _make_instance(name="test-inst", address="1.2.3.4", username="ec2-user"):
+    return InstanceMetadata(
+        name=name, address=address, username=username,
+        cloud="aws", image="ami-123",
+    )
+
+
+INSTANCES = {"inst1": _make_instance()}
+
+
+class TestRunOnInstance:
+    @patch("core.executor.subprocess.run")
+    def test_successful_execution_and_collection(self, mock_run):
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0),
+        ]
+
+        result = _run_on_instance(
+            _make_instance(), "echo hello", "/tmp/ssh_config",
+            "/tmp/results", "/tmp/results.xml", 3600,
+        )
+
+        assert result.exit_code == 0
+        assert result.stdout == "ok"
+        assert result.result_file is not None
+
+    @patch("core.executor.subprocess.run")
+    def test_ssh_uses_list_args(self, mock_run):
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0),
+        ]
+
+        _run_on_instance(
+            _make_instance(), "echo hello", "/tmp/ssh_config",
+            "/tmp/results", "/tmp/results.xml", 3600,
+        )
+
+        ssh_call = mock_run.call_args_list[0]
+        assert ssh_call[0][0] == ["ssh", "-F", "/tmp/ssh_config", "ec2-user@1.2.3.4", "echo hello"]
+
+    @patch("core.executor.subprocess.run")
+    def test_command_failure(self, mock_run):
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="error"),
+            subprocess.CompletedProcess(args=[], returncode=0),
+        ]
+
+        result = _run_on_instance(
+            _make_instance(), "bad-cmd", "/tmp/ssh_config",
+            "/tmp/results", "/tmp/results.xml", 3600,
+        )
+
+        assert result.exit_code == 1
+        assert result.stderr == "error"
+
+    @patch("core.executor.subprocess.run")
+    def test_timeout_handling(self, mock_run):
+        mock_run.side_effect = [
+            subprocess.TimeoutExpired(cmd="ssh", timeout=10),
+            subprocess.CompletedProcess(args=[], returncode=1),
+        ]
+
+        result = _run_on_instance(
+            _make_instance(), "slow-cmd", "/tmp/ssh_config",
+            "/tmp/results", "/tmp/results.xml", 10,
+        )
+
+        assert result.exit_code == 124
+        assert "timed out" in result.stderr
+
+    @patch("core.executor.subprocess.run")
+    def test_ssh_connection_error(self, mock_run):
+        mock_run.side_effect = [
+            Exception("Connection refused"),
+            subprocess.CompletedProcess(args=[], returncode=1),
+        ]
+
+        result = _run_on_instance(
+            _make_instance(), "cmd", "/tmp/ssh_config",
+            "/tmp/results", "/tmp/results.xml", 3600,
+        )
+
+        assert result.exit_code == 1
+        assert "Connection refused" in result.stderr
+
+    @patch("core.executor.subprocess.run")
+    def test_scp_failure_sets_result_file_none(self, mock_run):
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=1),
+        ]
+
+        result = _run_on_instance(
+            _make_instance(), "cmd", "/tmp/ssh_config",
+            "/tmp/results", "/tmp/results.xml", 3600,
+        )
+
+        assert result.exit_code == 0
+        assert result.result_file is None
+
+    @patch("core.executor.subprocess.run")
+    def test_scp_exception_sets_result_file_none(self, mock_run):
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            Exception("scp failed"),
+        ]
+
+        result = _run_on_instance(
+            _make_instance(), "cmd", "/tmp/ssh_config",
+            "/tmp/results", "/tmp/results.xml", 3600,
+        )
+
+        assert result.result_file is None
+
+
+class TestExecute:
+    @patch("core.executor._run_on_instance")
+    @patch("core.executor.os.makedirs")
+    def test_returns_execution_result(self, mock_makedirs, mock_run):
+        mock_run.return_value = InstanceResult(
+            instance_name="test-inst", exit_code=0,
+            result_file="/tmp/results/instance-test-inst.xml",
+            stdout="ok", stderr="",
+        )
+
+        result = execute(INSTANCES, "echo hello", "/tmp/ssh_config", "/tmp/results")
+
+        assert isinstance(result, ExecutionResult)
+        assert len(result.instance_results) == 1
+        assert result.all_passed is True
+
+    @patch("core.executor._run_on_instance")
+    @patch("core.executor.os.makedirs")
+    def test_all_passed_false_on_failure(self, mock_makedirs, mock_run):
+        mock_run.return_value = InstanceResult(
+            instance_name="test-inst", exit_code=1,
+            result_file=None, stdout="", stderr="fail",
+        )
+
+        result = execute(INSTANCES, "bad-cmd", "/tmp/ssh_config", "/tmp/results")
+
+        assert result.all_passed is False
+
+    @patch("core.executor._run_on_instance")
+    @patch("core.executor.os.makedirs")
+    def test_multiple_instances(self, mock_makedirs, mock_run):
+        mock_run.side_effect = [
+            InstanceResult("inst-a", 0, "/tmp/r/a.xml", "ok", ""),
+            InstanceResult("inst-b", 1, None, "", "fail"),
+        ]
+
+        instances = {
+            "a": _make_instance(name="inst-a", address="1.1.1.1"),
+            "b": _make_instance(name="inst-b", address="2.2.2.2"),
+        }
+
+        result = execute(instances, "cmd", "/tmp/ssh_config", "/tmp/r")
+
+        assert len(result.instance_results) == 2
+        assert result.all_passed is False
+
+    @patch("core.executor._run_on_instance")
+    @patch("core.executor.os.makedirs")
+    def test_creates_results_dir(self, mock_makedirs, mock_run):
+        mock_run.return_value = InstanceResult(
+            instance_name="test-inst", exit_code=0,
+            result_file=None, stdout="", stderr="",
+        )
+
+        execute(INSTANCES, "cmd", "/tmp/ssh_config", "/tmp/results")
+
+        mock_makedirs.assert_called_once_with("/tmp/results", exist_ok=True)
+
+
+class TestExecutionResult:
+    def test_all_passed_true(self):
+        result = ExecutionResult(instance_results=[
+            InstanceResult("a", 0, None, "", ""),
+            InstanceResult("b", 0, None, "", ""),
+        ])
+        assert result.all_passed is True
+
+    def test_all_passed_false(self):
+        result = ExecutionResult(instance_results=[
+            InstanceResult("a", 0, None, "", ""),
+            InstanceResult("b", 1, None, "", ""),
+        ])
+        assert result.all_passed is False
+
+    def test_empty_results(self):
+        result = ExecutionResult(instance_results=[])
+        assert result.all_passed is True


### PR DESCRIPTION
## Summary
- Add `core/executor.py` with `execute()` function for running commands on cloud instances via SSH using `subprocess.run` with list args
- Uses `ThreadPoolExecutor` for parallel execution across instances and SCP for result file collection
- Typed `InstanceResult` and `ExecutionResult` dataclasses with `all_passed` property
- 14 unit tests with 100% coverage in `test/test_executor.py`

## Test plan
- [x] All 14 tests pass (`pytest test/test_executor.py -v`)
- [x] flake8 passes with no warnings
- [x] 100% code coverage verified