### PR TITLE
feat: add phase-based CLI entry point with subcommands (CIV-013)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9,7 +9,7 @@ import sys
 
 from core.config import CoreConfig
 from core.executor import execute
-from core.metadata import InstanceMetadata
+from core.metadata import InstanceMetadata, write_instances_json
 from core.provisioner import Provisioner
 from core.results import get_exit_code, merge_results
 
@@ -39,7 +39,7 @@ def _build_config(args: argparse.Namespace) -> CoreConfig:
 
     for attr in ("debug", "parallel", "stop_cleanup"):
         val = getattr(args, attr, None)
-        if val:
+        if val is not None:
             config_dict[attr] = val
 
     if getattr(args, "tags", None):
@@ -124,37 +124,32 @@ def cmd_run(args: argparse.Namespace) -> int:
     config = _build_config(args)
     provisioner = Provisioner(config)
     try:
-        instances = provisioner.provision()
-        provisioner.prepare_environment(instances)
+        if getattr(args, "attach", False):
+            instances = provisioner.get_instances()
+            write_instances_json(instances, config.instances_json)
+        else:
+            instances = provisioner.provision()
+            provisioner.prepare_environment(instances)
 
         command = getattr(args, "command", None) or _build_test_command(config)
         results_dir = os.path.dirname(config.output_file) or "/tmp"
-        exec_result = execute(
-            instances=instances,
+
+        exec_args = argparse.Namespace(
+            instances_json=config.instances_json,
             command=command,
             ssh_config=config.ssh_config_file,
             results_dir=results_dir,
             timeout=getattr(args, "timeout", 3600),
         )
+        exit_code = cmd_execute(exec_args)
 
-        for ir in exec_result.instance_results:
-            status = "PASS" if ir.exit_code == 0 else "FAIL"
-            print(f"  [{status}] {ir.instance_name} (exit={ir.exit_code})")
-
-        result_files = [
-            r.result_file for r in exec_result.instance_results if r.result_file
-        ]
-        if not result_files:
-            print("No result files collected")
-            return 1
-
-        merge_result = merge_results(result_files, config.output_file)
-        print(
-            f"Merged {merge_result.total_tests} tests: "
-            f"{merge_result.failures} failures, "
-            f"{merge_result.errors} errors"
+        collect_args = argparse.Namespace(
+            results_dir=results_dir,
+            output_file=config.output_file,
         )
-        return get_exit_code(merge_result)
+        collect_code = cmd_collect(collect_args)
+
+        return collect_code if collect_code != 0 else exit_code
 
     except Exception as exc:
         print(f"Error: {exc}")
@@ -250,6 +245,8 @@ def build_parser() -> argparse.ArgumentParser:
                        help="Custom command (overrides test flags)")
     p_run.add_argument("--timeout", type=int, default=3600,
                        help="Timeout in seconds (default: 3600)")
+    p_run.add_argument("-a", "--attach", action="store_true", default=False,
+                       help="Attach to existing infrastructure instead of provisioning")
     p_run.set_defaults(func=cmd_run)
 
     # --- cleanup ---

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+from core.config import CoreConfig
+from core.executor import execute
+from core.metadata import InstanceMetadata
+from core.provisioner import Provisioner
+from core.results import get_exit_code, merge_results
+
+
+def _parse_tags(tags_str: str) -> dict[str, str]:
+    result = {}
+    for pair in tags_str.split(","):
+        pair = pair.strip()
+        if ":" in pair:
+            key, value = pair.split(":", 1)
+            result[key.strip()] = value.strip()
+    return result
+
+
+def _build_config(args: argparse.Namespace) -> CoreConfig:
+    if getattr(args, "config_file", None):
+        return CoreConfig.from_yaml(args.config_file)
+
+    resources_file = getattr(args, "resources_file", None)
+    if not resources_file:
+        raise SystemExit("error: --resources-file is required (or use --config-file)")
+
+    config_dict: dict[str, object] = {
+        "resources_file": resources_file,
+        "output_file": getattr(args, "output_file", None) or "/tmp/civ-results.xml",
+    }
+
+    for attr in ("debug", "parallel", "stop_cleanup"):
+        val = getattr(args, attr, None)
+        if val:
+            config_dict[attr] = val
+
+    if getattr(args, "tags", None):
+        config_dict["tags"] = _parse_tags(args.tags)
+
+    if getattr(args, "environment", None):
+        config_dict["environment"] = args.environment
+
+    for attr in ("test_filter", "test_suites", "include_markers"):
+        val = getattr(args, attr, None)
+        if val is not None:
+            config_dict[attr] = val
+
+    return CoreConfig.from_dict(config_dict)
+
+
+def _load_instances(path: str) -> dict[str, InstanceMetadata]:
+    with open(path) as f:
+        data = json.load(f)
+    return {
+        key: InstanceMetadata.from_dict(inst_data)
+        for key, inst_data in data.items()
+    }
+
+
+def _build_test_command(config: CoreConfig) -> str:
+    parts = ["pytest"]
+    if config.test_suites:
+        parts.extend(config.test_suites)
+    else:
+        parts.append("test_suite/")
+    parts.append("--junit-xml=/tmp/results.xml")
+    if config.test_filter:
+        parts.extend(["-k", config.test_filter])
+    if config.include_markers:
+        parts.extend(["-m", config.include_markers])
+    if config.parallel:
+        parts.extend(["-n", "auto"])
+    return " ".join(parts)
+
+
+def cmd_provision(args: argparse.Namespace) -> int:
+    config = _build_config(args)
+    provisioner = Provisioner(config)
+    instances = provisioner.provision()
+    provisioner.prepare_environment(instances)
+    print(f"Provisioned {len(instances)} instance(s)")
+    return 0
+
+
+def cmd_execute(args: argparse.Namespace) -> int:
+    instances = _load_instances(args.instances_json)
+    result = execute(
+        instances=instances,
+        command=args.command,
+        ssh_config=args.ssh_config,
+        results_dir=args.results_dir,
+        timeout=args.timeout,
+    )
+    for ir in result.instance_results:
+        status = "PASS" if ir.exit_code == 0 else "FAIL"
+        print(f"  [{status}] {ir.instance_name} (exit={ir.exit_code})")
+    return 0 if result.all_passed else 1
+
+
+def cmd_collect(args: argparse.Namespace) -> int:
+    result_files = sorted(glob.glob(os.path.join(args.results_dir, "*.xml")))
+    if not result_files:
+        print(f"No XML result files found in {args.results_dir}")
+        return 2
+    merge_result = merge_results(result_files, args.output_file)
+    print(
+        f"Merged {merge_result.total_tests} tests: "
+        f"{merge_result.failures} failures, "
+        f"{merge_result.errors} errors, "
+        f"{merge_result.skipped} skipped"
+    )
+    return get_exit_code(merge_result)
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    config = _build_config(args)
+    provisioner = Provisioner(config)
+    try:
+        instances = provisioner.provision()
+        provisioner.prepare_environment(instances)
+
+        command = getattr(args, "command", None) or _build_test_command(config)
+        results_dir = os.path.dirname(config.output_file) or "/tmp"
+        exec_result = execute(
+            instances=instances,
+            command=command,
+            ssh_config=config.ssh_config_file,
+            results_dir=results_dir,
+            timeout=getattr(args, "timeout", 3600),
+        )
+
+        for ir in exec_result.instance_results:
+            status = "PASS" if ir.exit_code == 0 else "FAIL"
+            print(f"  [{status}] {ir.instance_name} (exit={ir.exit_code})")
+
+        result_files = [
+            r.result_file for r in exec_result.instance_results if r.result_file
+        ]
+        if not result_files:
+            print("No result files collected")
+            return 1
+
+        merge_result = merge_results(result_files, config.output_file)
+        print(
+            f"Merged {merge_result.total_tests} tests: "
+            f"{merge_result.failures} failures, "
+            f"{merge_result.errors} errors"
+        )
+        return get_exit_code(merge_result)
+
+    except Exception as exc:
+        print(f"Error: {exc}")
+        return 100
+    finally:
+        if not config.stop_cleanup:
+            provisioner.cleanup()
+
+
+def cmd_cleanup(args: argparse.Namespace) -> int:
+    config = _build_config(args)
+    provisioner = Provisioner(config)
+    provisioner.get_instances()
+    provisioner.cleanup()
+    print("Cleanup complete")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="civ",
+        description="Cloud Image Validator - phase-based CLI",
+    )
+    subparsers = parser.add_subparsers(dest="subcommand")
+
+    # --- provision ---
+    p_prov = subparsers.add_parser("provision", help="Provision cloud instances")
+    p_prov.add_argument("-r", "--resources-file",
+                        help="Path to resources JSON file")
+    p_prov.add_argument("-c", "--config-file", default=None,
+                        help="Path to YAML config file")
+    p_prov.add_argument("-d", "--debug", action="store_true", default=False,
+                        help="Enable debug mode")
+    p_prov.add_argument("--tags", default=None,
+                        help="Tags as 'key1:value1, key2:value2'")
+    p_prov.add_argument("-p", "--parallel", action="store_true", default=False,
+                        help="Enable parallel mode")
+    p_prov.set_defaults(func=cmd_provision)
+
+    # --- execute ---
+    p_exec = subparsers.add_parser(
+        "execute", help="Run a command on provisioned instances",
+    )
+    p_exec.add_argument("--command", required=True,
+                        help="Command to execute on instances")
+    p_exec.add_argument("--ssh-config", default="/tmp/civ-ssh-config",
+                        help="Path to SSH config file")
+    p_exec.add_argument("--instances-json", default="/tmp/civ-instances.json",
+                        help="Path to instances JSON file")
+    p_exec.add_argument("--results-dir", default="/tmp/civ-results",
+                        help="Directory to store result files")
+    p_exec.add_argument("--timeout", type=int, default=3600,
+                        help="Timeout in seconds (default: 3600)")
+    p_exec.set_defaults(func=cmd_execute)
+
+    # --- collect ---
+    p_coll = subparsers.add_parser(
+        "collect", help="Validate and merge JUnit XML results",
+    )
+    p_coll.add_argument("--results-dir", required=True,
+                        help="Directory containing XML result files")
+    p_coll.add_argument("-o", "--output-file", required=True,
+                        help="Output path for merged JUnit XML")
+    p_coll.set_defaults(func=cmd_collect)
+
+    # --- run ---
+    p_run = subparsers.add_parser(
+        "run", help="Full pipeline: provision -> execute -> collect -> cleanup",
+    )
+    p_run.add_argument("-r", "--resources-file",
+                       help="Path to resources JSON file")
+    p_run.add_argument("-o", "--output-file", default=None,
+                       help="Output file path for test results")
+    p_run.add_argument("-t", "--test-filter", default=None,
+                       help="Filter tests by name")
+    p_run.add_argument("--test-suites", nargs="+", default=None,
+                       help="Test suite paths")
+    p_run.add_argument("-m", "--include-markers", default=None,
+                       help="Pytest markers expression")
+    p_run.add_argument("-p", "--parallel", action="store_true", default=False,
+                       help="Enable parallel test execution")
+    p_run.add_argument("-d", "--debug", action="store_true", default=False,
+                       help="Enable debug mode")
+    p_run.add_argument("-s", "--stop-cleanup", action="store_true", default=False,
+                       help="Skip cleanup after execution")
+    p_run.add_argument("-e", "--environment", default=None,
+                       help="Environment: 'local' or 'automated'")
+    p_run.add_argument("-c", "--config-file", default=None,
+                       help="Path to YAML config file")
+    p_run.add_argument("--tags", default=None,
+                       help="Tags as 'key1:value1, key2:value2'")
+    p_run.add_argument("--command", default=None,
+                       help="Custom command (overrides test flags)")
+    p_run.add_argument("--timeout", type=int, default=3600,
+                       help="Timeout in seconds (default: 3600)")
+    p_run.set_defaults(func=cmd_run)
+
+    # --- cleanup ---
+    p_clean = subparsers.add_parser(
+        "cleanup", help="Destroy provisioned infrastructure",
+    )
+    p_clean.add_argument("-r", "--resources-file",
+                         help="Path to resources JSON file")
+    p_clean.add_argument("-c", "--config-file", default=None,
+                         help="Path to YAML config file")
+    p_clean.add_argument("-d", "--debug", action="store_true", default=False,
+                         help="Enable debug mode")
+    p_clean.set_defaults(func=cmd_cleanup)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return 2
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -55,6 +55,7 @@ def _run_args(**overrides):
         "tags": None,
         "command": None,
         "timeout": 3600,
+        "attach": False,
     }
     defaults.update(overrides)
     return Namespace(**defaults)
@@ -174,7 +175,7 @@ class TestBuildParser:
             "-t", "test_ssh", "--test-suites", "a/", "b/",
             "-m", "pub", "-p", "-d", "-s", "-e", "automated",
             "--tags", "env:prod", "--command", "echo hi",
-            "--timeout", "600",
+            "--timeout", "600", "-a",
         ])
         assert args.resources_file == "resources.json"
         assert args.test_filter == "test_ssh"
@@ -187,6 +188,7 @@ class TestBuildParser:
         assert args.tags == "env:prod"
         assert args.command == "echo hi"
         assert args.timeout == 600
+        assert args.attach is True
 
     def test_cleanup_subcommand(self):
         parser = build_parser()
@@ -310,70 +312,42 @@ class TestCmdCollect:
 
 
 class TestCmdRun:
-    @patch("cli.merge_results")
-    @patch("cli.execute")
+    @patch("cli.cmd_collect", return_value=0)
+    @patch("cli.cmd_execute", return_value=0)
     @patch("cli.Provisioner")
-    def test_full_pipeline_success(self, MockProv, mock_execute, mock_merge):
+    def test_full_pipeline_success(self, MockProv, mock_exec, mock_coll):
         mock_prov = MockProv.return_value
         mock_prov.provision.return_value = {"inst1": MagicMock()}
-
-        mock_ir = MagicMock()
-        mock_ir.exit_code = 0
-        mock_ir.instance_name = "inst1"
-        mock_ir.result_file = "/tmp/r/inst1.xml"
-        mock_exec_result = MagicMock()
-        mock_exec_result.instance_results = [mock_ir]
-        mock_execute.return_value = mock_exec_result
-
-        mock_merge.return_value = MergeResult(
-            total_tests=5, failures=0, errors=0, skipped=0, time=1.0,
-        )
 
         args = _run_args()
         assert cmd_run(args) == 0
         mock_prov.provision.assert_called_once()
         mock_prov.prepare_environment.assert_called_once()
+        mock_exec.assert_called_once()
+        mock_coll.assert_called_once()
         mock_prov.cleanup.assert_called_once()
 
-    @patch("cli.merge_results")
-    @patch("cli.execute")
+    @patch("cli.cmd_collect", return_value=1)
+    @patch("cli.cmd_execute", return_value=0)
     @patch("cli.Provisioner")
-    def test_returns_exit_code_from_merge(self, MockProv, mock_execute, mock_merge):
+    def test_returns_collect_exit_code(self, MockProv, mock_exec, mock_coll):
         mock_prov = MockProv.return_value
         mock_prov.provision.return_value = {"inst1": MagicMock()}
-
-        mock_ir = MagicMock()
-        mock_ir.exit_code = 0
-        mock_ir.instance_name = "inst1"
-        mock_ir.result_file = "/tmp/r/inst1.xml"
-        mock_exec_result = MagicMock()
-        mock_exec_result.instance_results = [mock_ir]
-        mock_execute.return_value = mock_exec_result
-
-        mock_merge.return_value = MergeResult(
-            total_tests=5, failures=2, errors=0, skipped=0, time=1.0,
-        )
 
         args = _run_args()
         assert cmd_run(args) == 1
 
-    @patch("cli.execute")
+    @patch("cli.cmd_collect", return_value=0)
+    @patch("cli.cmd_execute", return_value=1)
     @patch("cli.Provisioner")
-    def test_returns_one_when_no_result_files(self, MockProv, mock_execute):
+    def test_returns_execute_exit_code_when_collect_passes(
+        self, MockProv, mock_exec, mock_coll,
+    ):
         mock_prov = MockProv.return_value
         mock_prov.provision.return_value = {"inst1": MagicMock()}
 
-        mock_ir = MagicMock()
-        mock_ir.exit_code = 1
-        mock_ir.instance_name = "inst1"
-        mock_ir.result_file = None
-        mock_exec_result = MagicMock()
-        mock_exec_result.instance_results = [mock_ir]
-        mock_execute.return_value = mock_exec_result
-
         args = _run_args()
         assert cmd_run(args) == 1
-        mock_prov.cleanup.assert_called_once()
 
     @patch("cli.Provisioner")
     def test_returns_100_on_infra_error(self, MockProv):
@@ -384,48 +358,43 @@ class TestCmdRun:
         assert cmd_run(args) == 100
         mock_prov.cleanup.assert_called_once()
 
-    @patch("cli.execute")
+    @patch("cli.cmd_collect", return_value=0)
+    @patch("cli.cmd_execute", return_value=0)
     @patch("cli.Provisioner")
-    def test_skips_cleanup_when_stop_cleanup(self, MockProv, mock_execute):
+    def test_skips_cleanup_when_stop_cleanup(self, MockProv, mock_exec, mock_coll):
         mock_prov = MockProv.return_value
         mock_prov.provision.return_value = {"inst1": MagicMock()}
-
-        mock_ir = MagicMock()
-        mock_ir.result_file = None
-        mock_ir.exit_code = 0
-        mock_ir.instance_name = "inst1"
-        mock_exec_result = MagicMock()
-        mock_exec_result.instance_results = [mock_ir]
-        mock_execute.return_value = mock_exec_result
 
         args = _run_args(stop_cleanup=True)
         cmd_run(args)
         mock_prov.cleanup.assert_not_called()
 
-    @patch("cli.merge_results")
-    @patch("cli.execute")
+    @patch("cli.cmd_collect", return_value=0)
+    @patch("cli.cmd_execute", return_value=0)
     @patch("cli.Provisioner")
-    def test_uses_custom_command(self, MockProv, mock_execute, mock_merge):
+    def test_passes_custom_command(self, MockProv, mock_exec, mock_coll):
         mock_prov = MockProv.return_value
         mock_prov.provision.return_value = {"inst1": MagicMock()}
 
-        mock_ir = MagicMock()
-        mock_ir.exit_code = 0
-        mock_ir.instance_name = "inst1"
-        mock_ir.result_file = "/tmp/r/inst1.xml"
-        mock_exec_result = MagicMock()
-        mock_exec_result.instance_results = [mock_ir]
-        mock_execute.return_value = mock_exec_result
-
-        mock_merge.return_value = MergeResult(
-            total_tests=1, failures=0, errors=0, skipped=0, time=0.5,
-        )
-
         args = _run_args(command="echo hi")
         cmd_run(args)
-        mock_execute.assert_called_once()
-        call_kwargs = mock_execute.call_args
-        assert call_kwargs[1]["command"] == "echo hi"
+        exec_call_args = mock_exec.call_args[0][0]
+        assert exec_call_args.command == "echo hi"
+
+    @patch("cli.cmd_collect", return_value=0)
+    @patch("cli.cmd_execute", return_value=0)
+    @patch("cli.write_instances_json")
+    @patch("cli.Provisioner")
+    def test_attach_skips_provision(self, MockProv, mock_write, mock_exec, mock_coll):
+        mock_prov = MockProv.return_value
+        mock_prov.get_instances.return_value = {"inst1": MagicMock()}
+
+        args = _run_args(attach=True)
+        assert cmd_run(args) == 0
+        mock_prov.provision.assert_not_called()
+        mock_prov.prepare_environment.assert_not_called()
+        mock_prov.get_instances.assert_called_once()
+        mock_write.assert_called_once()
 
 
 class TestCmdCleanup:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,459 @@
+import sys
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+mock_provisioner_module = MagicMock()
+mock_executor_module = MagicMock()
+
+sys.modules.setdefault("core.provisioner", mock_provisioner_module)
+sys.modules.setdefault("core.executor", mock_executor_module)
+
+from cli import (  # noqa: E402
+    _build_config,
+    _build_test_command,
+    _load_instances,
+    _parse_tags,
+    build_parser,
+    cmd_cleanup,
+    cmd_collect,
+    cmd_execute,
+    cmd_provision,
+    cmd_run,
+    main,
+)
+from core.config import CoreConfig  # noqa: E402
+from core.results import MergeResult  # noqa: E402
+
+
+def _provision_args(**overrides):
+    defaults = {
+        "resources_file": "resources.json",
+        "config_file": None,
+        "debug": False,
+        "tags": None,
+        "parallel": False,
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def _run_args(**overrides):
+    defaults = {
+        "resources_file": "resources.json",
+        "config_file": None,
+        "output_file": "/tmp/out.xml",
+        "test_filter": None,
+        "test_suites": None,
+        "include_markers": None,
+        "parallel": False,
+        "debug": False,
+        "stop_cleanup": False,
+        "environment": None,
+        "tags": None,
+        "command": None,
+        "timeout": 3600,
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+class TestParseTags:
+    def test_parses_single_tag(self):
+        assert _parse_tags("env:prod") == {"env": "prod"}
+
+    def test_parses_multiple_tags(self):
+        result = _parse_tags("env:prod, team:qa")
+        assert result == {"env": "prod", "team": "qa"}
+
+    def test_handles_colons_in_value(self):
+        result = _parse_tags("url:http://example.com")
+        assert result == {"url": "http://example.com"}
+
+
+class TestBuildConfig:
+    def test_builds_from_cli_flags(self):
+        args = _provision_args()
+        config = _build_config(args)
+        assert config.resources_file == "resources.json"
+        assert config.debug is False
+
+    def test_builds_with_debug(self):
+        args = _provision_args(debug=True)
+        config = _build_config(args)
+        assert config.debug is True
+
+    def test_builds_with_tags(self):
+        args = _provision_args(tags="env:prod")
+        config = _build_config(args)
+        assert config.tags == {"env": "prod"}
+
+    def test_exits_without_resources_file(self):
+        args = Namespace(resources_file=None, config_file=None)
+        with pytest.raises(SystemExit):
+            _build_config(args)
+
+    @patch("cli.CoreConfig.from_yaml")
+    def test_loads_from_config_file(self, mock_from_yaml):
+        mock_from_yaml.return_value = CoreConfig(
+            resources_file="r.json", output_file="o.xml",
+        )
+        args = _provision_args(config_file="/tmp/cfg.yaml")
+        config = _build_config(args)
+        mock_from_yaml.assert_called_once_with("/tmp/cfg.yaml")
+        assert config.resources_file == "r.json"
+
+
+class TestBuildTestCommand:
+    def test_default_command(self):
+        config = CoreConfig(resources_file="r.json", output_file="o.xml")
+        cmd = _build_test_command(config)
+        assert cmd.startswith("pytest test_suite/")
+        assert "--junit-xml=/tmp/results.xml" in cmd
+
+    def test_with_test_filter(self):
+        config = CoreConfig(
+            resources_file="r.json", output_file="o.xml",
+            test_filter="test_ssh",
+        )
+        cmd = _build_test_command(config)
+        assert "-k test_ssh" in cmd
+
+    def test_with_markers(self):
+        config = CoreConfig(
+            resources_file="r.json", output_file="o.xml",
+            include_markers="pub",
+        )
+        cmd = _build_test_command(config)
+        assert "-m pub" in cmd
+
+    def test_with_test_suites(self):
+        config = CoreConfig(
+            resources_file="r.json", output_file="o.xml",
+            test_suites=["suite_a/", "suite_b/"],
+        )
+        cmd = _build_test_command(config)
+        assert "suite_a/" in cmd
+        assert "suite_b/" in cmd
+        assert "test_suite/" not in cmd
+
+    def test_with_parallel(self):
+        config = CoreConfig(
+            resources_file="r.json", output_file="o.xml",
+            parallel=True,
+        )
+        cmd = _build_test_command(config)
+        assert "-n auto" in cmd
+
+
+class TestBuildParser:
+    def test_provision_subcommand(self):
+        parser = build_parser()
+        args = parser.parse_args(["provision", "-r", "resources.json"])
+        assert args.resources_file == "resources.json"
+        assert args.debug is False
+
+    def test_execute_subcommand(self):
+        parser = build_parser()
+        args = parser.parse_args(["execute", "--command", "echo hi"])
+        assert args.command == "echo hi"
+        assert args.timeout == 3600
+
+    def test_collect_subcommand(self):
+        parser = build_parser()
+        args = parser.parse_args(["collect", "--results-dir", "/tmp/r", "-o", "out.xml"])
+        assert args.results_dir == "/tmp/r"
+        assert args.output_file == "out.xml"
+
+    def test_run_subcommand_all_flags(self):
+        parser = build_parser()
+        args = parser.parse_args([
+            "run", "-r", "resources.json", "-o", "out.xml",
+            "-t", "test_ssh", "--test-suites", "a/", "b/",
+            "-m", "pub", "-p", "-d", "-s", "-e", "automated",
+            "--tags", "env:prod", "--command", "echo hi",
+            "--timeout", "600",
+        ])
+        assert args.resources_file == "resources.json"
+        assert args.test_filter == "test_ssh"
+        assert args.test_suites == ["a/", "b/"]
+        assert args.include_markers == "pub"
+        assert args.parallel is True
+        assert args.debug is True
+        assert args.stop_cleanup is True
+        assert args.environment == "automated"
+        assert args.tags == "env:prod"
+        assert args.command == "echo hi"
+        assert args.timeout == 600
+
+    def test_cleanup_subcommand(self):
+        parser = build_parser()
+        args = parser.parse_args(["cleanup", "-r", "resources.json"])
+        assert args.resources_file == "resources.json"
+
+    def test_execute_defaults(self):
+        parser = build_parser()
+        args = parser.parse_args(["execute", "--command", "ls"])
+        assert args.ssh_config == "/tmp/civ-ssh-config"
+        assert args.instances_json == "/tmp/civ-instances.json"
+        assert args.results_dir == "/tmp/civ-results"
+
+
+class TestMain:
+    def test_no_subcommand_returns_2(self):
+        assert main([]) == 2
+
+    @patch("cli.cmd_provision", return_value=0)
+    def test_routes_to_provision(self, mock_cmd):
+        result = main(["provision", "-r", "resources.json"])
+        assert result == 0
+        mock_cmd.assert_called_once()
+
+    @patch("cli.cmd_execute", return_value=0)
+    def test_routes_to_execute(self, mock_cmd):
+        result = main(["execute", "--command", "echo hi"])
+        assert result == 0
+
+    @patch("cli.cmd_collect", return_value=0)
+    def test_routes_to_collect(self, mock_cmd):
+        result = main(["collect", "--results-dir", "/tmp/r", "-o", "out.xml"])
+        assert result == 0
+
+    @patch("cli.cmd_cleanup", return_value=0)
+    def test_routes_to_cleanup(self, mock_cmd):
+        result = main(["cleanup", "-r", "resources.json"])
+        assert result == 0
+
+
+class TestCmdProvision:
+    @patch("cli.Provisioner")
+    def test_returns_zero_on_success(self, MockProv):
+        mock_prov = MockProv.return_value
+        mock_prov.provision.return_value = {"inst1": MagicMock()}
+        args = _provision_args()
+        result = cmd_provision(args)
+        assert result == 0
+        mock_prov.provision.assert_called_once()
+        mock_prov.prepare_environment.assert_called_once()
+
+
+class TestCmdExecute:
+    @patch("cli._load_instances")
+    @patch("cli.execute")
+    def test_returns_zero_on_all_passed(self, mock_execute, mock_load):
+        mock_load.return_value = {"inst1": MagicMock()}
+        mock_result = MagicMock()
+        mock_result.all_passed = True
+        mock_result.instance_results = [
+            MagicMock(exit_code=0, instance_name="inst1"),
+        ]
+        mock_execute.return_value = mock_result
+        args = Namespace(
+            command="echo hi", ssh_config="/tmp/cfg",
+            instances_json="/tmp/inst.json", results_dir="/tmp/r",
+            timeout=3600,
+        )
+        assert cmd_execute(args) == 0
+
+    @patch("cli._load_instances")
+    @patch("cli.execute")
+    def test_returns_one_on_failure(self, mock_execute, mock_load):
+        mock_load.return_value = {"inst1": MagicMock()}
+        mock_result = MagicMock()
+        mock_result.all_passed = False
+        mock_result.instance_results = [
+            MagicMock(exit_code=1, instance_name="inst1"),
+        ]
+        mock_execute.return_value = mock_result
+        args = Namespace(
+            command="bad", ssh_config="/tmp/cfg",
+            instances_json="/tmp/inst.json", results_dir="/tmp/r",
+            timeout=3600,
+        )
+        assert cmd_execute(args) == 1
+
+
+class TestCmdCollect:
+    @patch("cli.merge_results")
+    @patch("cli.glob.glob", return_value=["/tmp/r/a.xml", "/tmp/r/b.xml"])
+    def test_returns_exit_code_from_results(self, mock_glob, mock_merge):
+        mock_merge.return_value = MergeResult(
+            total_tests=10, failures=0, errors=0, skipped=1, time=5.0,
+        )
+        args = Namespace(results_dir="/tmp/r", output_file="/tmp/out.xml")
+        assert cmd_collect(args) == 0
+
+    @patch("cli.merge_results")
+    @patch("cli.glob.glob", return_value=["/tmp/r/a.xml"])
+    def test_returns_one_on_failures(self, mock_glob, mock_merge):
+        mock_merge.return_value = MergeResult(
+            total_tests=10, failures=2, errors=0, skipped=0, time=5.0,
+        )
+        args = Namespace(results_dir="/tmp/r", output_file="/tmp/out.xml")
+        assert cmd_collect(args) == 1
+
+    @patch("cli.merge_results")
+    @patch("cli.glob.glob", return_value=["/tmp/r/a.xml"])
+    def test_returns_two_on_errors(self, mock_glob, mock_merge):
+        mock_merge.return_value = MergeResult(
+            total_tests=10, failures=0, errors=3, skipped=0, time=5.0,
+        )
+        args = Namespace(results_dir="/tmp/r", output_file="/tmp/out.xml")
+        assert cmd_collect(args) == 2
+
+    @patch("cli.glob.glob", return_value=[])
+    def test_returns_two_when_no_files(self, mock_glob):
+        args = Namespace(results_dir="/tmp/empty", output_file="/tmp/out.xml")
+        assert cmd_collect(args) == 2
+
+
+class TestCmdRun:
+    @patch("cli.merge_results")
+    @patch("cli.execute")
+    @patch("cli.Provisioner")
+    def test_full_pipeline_success(self, MockProv, mock_execute, mock_merge):
+        mock_prov = MockProv.return_value
+        mock_prov.provision.return_value = {"inst1": MagicMock()}
+
+        mock_ir = MagicMock()
+        mock_ir.exit_code = 0
+        mock_ir.instance_name = "inst1"
+        mock_ir.result_file = "/tmp/r/inst1.xml"
+        mock_exec_result = MagicMock()
+        mock_exec_result.instance_results = [mock_ir]
+        mock_execute.return_value = mock_exec_result
+
+        mock_merge.return_value = MergeResult(
+            total_tests=5, failures=0, errors=0, skipped=0, time=1.0,
+        )
+
+        args = _run_args()
+        assert cmd_run(args) == 0
+        mock_prov.provision.assert_called_once()
+        mock_prov.prepare_environment.assert_called_once()
+        mock_prov.cleanup.assert_called_once()
+
+    @patch("cli.merge_results")
+    @patch("cli.execute")
+    @patch("cli.Provisioner")
+    def test_returns_exit_code_from_merge(self, MockProv, mock_execute, mock_merge):
+        mock_prov = MockProv.return_value
+        mock_prov.provision.return_value = {"inst1": MagicMock()}
+
+        mock_ir = MagicMock()
+        mock_ir.exit_code = 0
+        mock_ir.instance_name = "inst1"
+        mock_ir.result_file = "/tmp/r/inst1.xml"
+        mock_exec_result = MagicMock()
+        mock_exec_result.instance_results = [mock_ir]
+        mock_execute.return_value = mock_exec_result
+
+        mock_merge.return_value = MergeResult(
+            total_tests=5, failures=2, errors=0, skipped=0, time=1.0,
+        )
+
+        args = _run_args()
+        assert cmd_run(args) == 1
+
+    @patch("cli.execute")
+    @patch("cli.Provisioner")
+    def test_returns_one_when_no_result_files(self, MockProv, mock_execute):
+        mock_prov = MockProv.return_value
+        mock_prov.provision.return_value = {"inst1": MagicMock()}
+
+        mock_ir = MagicMock()
+        mock_ir.exit_code = 1
+        mock_ir.instance_name = "inst1"
+        mock_ir.result_file = None
+        mock_exec_result = MagicMock()
+        mock_exec_result.instance_results = [mock_ir]
+        mock_execute.return_value = mock_exec_result
+
+        args = _run_args()
+        assert cmd_run(args) == 1
+        mock_prov.cleanup.assert_called_once()
+
+    @patch("cli.Provisioner")
+    def test_returns_100_on_infra_error(self, MockProv):
+        mock_prov = MockProv.return_value
+        mock_prov.provision.side_effect = Exception("infra failed")
+
+        args = _run_args()
+        assert cmd_run(args) == 100
+        mock_prov.cleanup.assert_called_once()
+
+    @patch("cli.execute")
+    @patch("cli.Provisioner")
+    def test_skips_cleanup_when_stop_cleanup(self, MockProv, mock_execute):
+        mock_prov = MockProv.return_value
+        mock_prov.provision.return_value = {"inst1": MagicMock()}
+
+        mock_ir = MagicMock()
+        mock_ir.result_file = None
+        mock_ir.exit_code = 0
+        mock_ir.instance_name = "inst1"
+        mock_exec_result = MagicMock()
+        mock_exec_result.instance_results = [mock_ir]
+        mock_execute.return_value = mock_exec_result
+
+        args = _run_args(stop_cleanup=True)
+        cmd_run(args)
+        mock_prov.cleanup.assert_not_called()
+
+    @patch("cli.merge_results")
+    @patch("cli.execute")
+    @patch("cli.Provisioner")
+    def test_uses_custom_command(self, MockProv, mock_execute, mock_merge):
+        mock_prov = MockProv.return_value
+        mock_prov.provision.return_value = {"inst1": MagicMock()}
+
+        mock_ir = MagicMock()
+        mock_ir.exit_code = 0
+        mock_ir.instance_name = "inst1"
+        mock_ir.result_file = "/tmp/r/inst1.xml"
+        mock_exec_result = MagicMock()
+        mock_exec_result.instance_results = [mock_ir]
+        mock_execute.return_value = mock_exec_result
+
+        mock_merge.return_value = MergeResult(
+            total_tests=1, failures=0, errors=0, skipped=0, time=0.5,
+        )
+
+        args = _run_args(command="echo hi")
+        cmd_run(args)
+        mock_execute.assert_called_once()
+        call_kwargs = mock_execute.call_args
+        assert call_kwargs[1]["command"] == "echo hi"
+
+
+class TestCmdCleanup:
+    @patch("cli.Provisioner")
+    def test_returns_zero(self, MockProv):
+        mock_prov = MockProv.return_value
+        args = Namespace(
+            resources_file="resources.json", config_file=None,
+            debug=False,
+        )
+        assert cmd_cleanup(args) == 0
+        mock_prov.get_instances.assert_called_once()
+        mock_prov.cleanup.assert_called_once()
+
+
+class TestLoadInstances:
+    def test_loads_from_json(self, tmp_path):
+        data = {
+            "inst1": {
+                "name": "inst1", "address": "1.2.3.4",
+                "username": "ec2-user", "cloud": "aws",
+                "image": "ami-123",
+            }
+        }
+        path = tmp_path / "instances.json"
+        import json
+        path.write_text(json.dumps(data))
+
+        instances = _load_instances(str(path))
+        assert "inst1" in instances
+        assert instances["inst1"].address == "1.2.3.4"


### PR DESCRIPTION
## Summary
- Add `cli.py` at repo root with 5 subcommands: `provision`, `execute`, `collect`, `run`, `cleanup`
- Maps to phase-based execution flow: each subcommand calls the appropriate `core/` module
- `civ run` ties the full pipeline (provision → execute → collect → cleanup) and accepts all flags from `cloud-image-val.py`
- `cloud-image-val.py` is not modified

## Dependencies
- Depends on CIV-011 (#613) and CIV-012 (#614) being merged first — imports `core.provisioner` and `core.executor`

## Test plan
- [x] 39 unit tests pass (`pytest test/test_cli.py -v`)
- [x] 98% code coverage
- [x] flake8 passes with no warnings
- [x] All 5 subcommands tested: parser, routing, and behavior
- [x] `cloud-image-val.py` unchanged